### PR TITLE
Change some Agents to Concept

### DIFF
--- a/delphi.py
+++ b/delphi.py
@@ -15,7 +15,6 @@ from delphi import app
 from typing import Optional
 from delphi.types import State
 from indra.sources import eidos
-from indra.statements import Influence, Agent
 from indra.assemblers import CAGAssembler
 from delphi.utils import flatMap
 from glob import glob

--- a/delphi/tests/test_core.py
+++ b/delphi/tests/test_core.py
@@ -1,15 +1,15 @@
-from indra.statements import Influence, Agent
+from indra.statements import Influence, Concept
 from delphi.core import *
 
 statements = [Influence(
-        Agent('X'),
-        Agent('Y'),
+        Concept('X'),
+        Concept('Y'),
         {'adjectives': ["small"], 'polarity': 1},
         {'adjectives': ["large"], 'polarity': -1},
     ),
     Influence(
-        Agent('Y'),
-        Agent('Z'),
+        Concept('Y'),
+        Concept('Z'),
         {'adjectives': ["big"], 'polarity': 1},
         {'adjectives': ["huge"], 'polarity': 1},
     ),


### PR DESCRIPTION
With the latest change in INDRA, we can use the more general `Concept` class as arguments of Influences, with `Agent` meant to be used for molecular agents. Looks like the only place this makes a difference here is in the test which I updated.