### PR TITLE
Moved export functions for CRA and ISI to separate module, delphi.export

### DIFF
--- a/delphi.py
+++ b/delphi.py
@@ -13,7 +13,8 @@ from argparse import (ArgumentParser, ArgumentTypeError, FileType,
                       ArgumentDefaultsHelpFormatter)
 
 def create_CRA_CAG(args):
-    from delphi.core import (isSimulable, create_dressed_CAG, export_to_CRA)
+    from delphi.core import (isSimulable, create_dressed_CAG)
+    from delphi.export import export_to_CRA
 
     with open(args.indra_statements, 'rb') as f:
         export_to_CRA(create_dressed_CAG(ltake(args.n_statements,
@@ -21,7 +22,8 @@ def create_CRA_CAG(args):
 
 
 def create_model(args):
-    from delphi.core import (isSimulable, create_dressed_CAG, export_to_ISI)
+    from delphi.core import (isSimulable, create_dressed_CAG)
+    from delphi.export import export_to_ISI
 
     with open(args.indra_statements, 'rb') as f:
         export_to_ISI(create_dressed_CAG(ltake(args.n_statements,

--- a/delphi/core.py
+++ b/delphi/core.py
@@ -89,7 +89,8 @@ def top_grounding_score(c: Concept, ontology="UN") -> float:
 
 
 @singledispatch
-def is_well_grounded(): pass
+def is_well_grounded():
+    pass
 
 
 @is_well_grounded.register(Concept)
@@ -306,93 +307,9 @@ def sample_sequences(
     return take(samples, repeatfunc(sample_sequence, CAG, s0, steps, Δt))
 
 
+
 def construct_executable_model(sts: List[Influence]) -> DiGraph:
     return add_conditional_probabilities(construct_CAG_skeleton(sts))
-
-
-def get_units(n: str) -> str:
-    return "units"
-
-
-def get_dtype(n: str) -> str:
-    return "real"
-
-
-def export_node(CAG: DiGraph, n) -> Dict[str, Union[str, List[str]]]:
-    """ Return dict suitable for exporting to JSON.
-
-    Args:
-        CAG: The causal analysis graph
-        n: A dict representing the data in a networkx DiGraph node.
-
-    Returns:
-        The node dict with additional fields for name, units, dtype, and
-        arguments.
-
-    """
-    n[1]["name"] = n[0]
-    n[1]["units"] = get_units(n[0])
-    n[1]["dtype"] = get_dtype(n[0])
-    n[1]["arguments"] = list(CAG.predecessors(n[0]))
-    return n[1]
-
-
-def export_edge(CAG: DiGraph, e):
-    return {"source": e[0], "target": e[1], "CPT": e[2]["CPT"]}
-
-
-def export_to_ISI(CAG: DiGraph, args) -> None:
-
-    s0 = construct_default_initial_state(get_latent_state_components(CAG))
-
-    s0.to_csv(args.output_variables_path, index_label="variable")
-
-    model = {
-        "name": "Dynamic Bayes Net Model",
-        "dateCreated": str(datetime.datetime.now()),
-        "variables": lmap(partial(export_node, CAG), CAG.nodes(data=True)),
-    }
-
-    with open(args.output_cag_json, "w") as f:
-        json.dump(model, f, indent=2)
-
-    for e in CAG.edges(data=True):
-        del e[2]["InfluenceStatements"]
-
-    with open(args.output_dressed_cag, "wb") as f:
-        pickle.dump(CAG, f)
-
-
-def construct_CPT(e, res=100):
-    kde = e[2]["ConditionalProbability"]
-    arr = np.squeeze(kde.dataset)
-    X = np.linspace(min(arr), max(arr), res)
-    Y = kde.evaluate(X) * (X[1] - X[0])
-    return {"beta": X.tolist(), "P(beta)": Y.tolist()}
-
-
-def export_to_CRA(CAG: DiGraph, Δt):
-    with open("cra_cag.json", "w") as f:
-        json.dump(
-            {
-                "name": "Dynamic Bayes Net Model",
-                "dateCreated": str(datetime.datetime.now()),
-                "variables": lmap(
-                    partial(export_node, CAG), CAG.nodes(data=True)
-                ),
-                "timeStep": Δt,
-                "CPTs": lmap(
-                    lambda e: {
-                        "source": e[0],
-                        "target": e[1],
-                        "CPT": construct_CPT(e),
-                    },
-                    CAG.edges(data=True),
-                ),
-            },
-            f,
-            indent=2,
-        )
 
 
 def load_model(filename: str) -> DiGraph:

--- a/delphi/export.py
+++ b/delphi/export.py
@@ -1,0 +1,92 @@
+import json
+import pickle
+import datetime
+from types import DiGraph
+from functools import partial
+from future.utils import lmap
+from core import construct_default_initial_state, get_latent_state_components
+
+
+def export_to_ISI(CAG: DiGraph, args) -> None:
+
+    s0 = construct_default_initial_state(get_latent_state_components(CAG))
+
+    s0.to_csv(args.output_variables_path, index_label="variable")
+
+    model = {
+        "name": "Dynamic Bayes Net Model",
+        "dateCreated": str(datetime.datetime.now()),
+        "variables": lmap(partial(_export_node, CAG), CAG.nodes(data=True)),
+    }
+
+    with open(args.output_cag_json, "w") as f:
+        json.dump(model, f, indent=2)
+
+    for e in CAG.edges(data=True):
+        del e[2]["InfluenceStatements"]
+
+    with open(args.output_dressed_cag, "wb") as f:
+        pickle.dump(CAG, f)
+
+
+def _get_units(n: str) -> str:
+    return "units"
+
+
+def _get_dtype(n: str) -> str:
+    return "real"
+
+
+def _export_node(CAG: DiGraph, n) -> Dict[str, Union[str, List[str]]]:
+    """ Return dict suitable for exporting to JSON.
+
+    Args:
+        CAG: The causal analysis graph
+        n: A dict representing the data in a networkx DiGraph node.
+
+    Returns:
+        The node dict with additional fields for name, units, dtype, and
+        arguments.
+
+    """
+    n[1]["name"] = n[0]
+    n[1]["units"] = _get_units(n[0])
+    n[1]["dtype"] = _get_dtype(n[0])
+    n[1]["arguments"] = list(CAG.predecessors(n[0]))
+    return n[1]
+
+
+def _export_edge(CAG: DiGraph, e):
+    return {"source": e[0], "target": e[1], "CPT": e[2]["CPT"]}
+
+
+def _construct_CPT(e, res=100):
+    kde = e[2]["ConditionalProbability"]
+    arr = np.squeeze(kde.dataset)
+    X = np.linspace(min(arr), max(arr), res)
+    Y = kde.evaluate(X) * (X[1] - X[0])
+    return {"beta": X.tolist(), "P(beta)": Y.tolist()}
+
+
+def export_to_CRA(CAG: DiGraph, Δt):
+    with open("cra_cag.json", "w") as f:
+        json.dump(
+            {
+                "name": "Dynamic Bayes Net Model",
+                "dateCreated": str(datetime.datetime.now()),
+                "variables": lmap(
+                    partial(_export_node, CAG), CAG.nodes(data=True)
+                ),
+                "timeStep": Δt,
+                "CPTs": lmap(
+                    lambda e: {
+                        "source": e[0],
+                        "target": e[1],
+                        "CPT": _construct_CPT(e),
+                    },
+                    CAG.edges(data=True),
+                ),
+            },
+            f,
+            indent=2,
+        )


### PR DESCRIPTION
This PR refactors Delphi by moving export-related functions from the core module to a separate export module.