### PR TITLE
Added script to clear Jupyter notebook outputs

### DIFF
--- a/notebooks/scripts/clear_outputs
+++ b/notebooks/scripts/clear_outputs
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Clear the outputs of a Jupyter notebook. Useful for version control.
+# Usage: ./clear_outputs <notebook>
+
+jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace "$1"


### PR DESCRIPTION
This PR adds a helper script to clear Jupyter notebook outputs. This is useful for version control.

@cl4yton @pauldhein 

Usage (when you are in the notebooks directory): 

```
./scripts/clear_outputs <notebook>
```