### PR TITLE
Using python3 for autoTranslate

### DIFF
--- a/delphi/program_analysis/autoTranslate/autoTranslate
+++ b/delphi/program_analysis/autoTranslate/autoTranslate
@@ -11,8 +11,8 @@ for file in "$@"; do
     astFile="$base".xml
     ( set -x; java fortran.ofp.FrontEnd --class fortran.ofp.XMLPrinter --verbosity 0 "$file" > "$astFile")
     pyFile="$base".py
-    ( set -x; python3.6 scripts/translate.py -f "$astFile" -g "$pyFile")
+    ( set -x; python3 scripts/translate.py -f "$astFile" -g "$pyFile")
     pyFiles+=" $pyFile"
 done
 
-( set -x; python3.6 scripts/genPGM.py -f$pyFiles -p pgm.json -l lambdas.py)
+( set -x; python3 scripts/genPGM.py -f$pyFiles -p pgm.json -l lambdas.py)

--- a/delphi/program_analysis/autoTranslate/crop_yield.py
+++ b/delphi/program_analysis/autoTranslate/crop_yield.py
@@ -1,0 +1,29 @@
+from typing import List
+
+def UPDATE_EST(RAIN: List[float], TOTAL_RAIN: List[float], YIELD_EST: List[float]):
+    TOTAL_RAIN[0] = (TOTAL_RAIN[0] + RAIN[0])
+    if (TOTAL_RAIN[0] <= 40):
+        YIELD_EST[0] = (-((((TOTAL_RAIN[0] - 40) ** 2) / 16)) + 100)
+    else:
+        YIELD_EST[0] = (-(TOTAL_RAIN[0]) + 140)
+
+def CROP_YIELD():
+    DAY: List[int] = [0]
+    RAIN: List[float] = [0.0]
+    YIELD_EST: List[float] = [0.0]
+    TOTAL_RAIN: List[float] = [0.0]
+    MAX_RAIN: List[float] = [0.0]
+    CONSISTENCY: List[float] = [0.0]
+    ABSORBTION: List[float] = [0.0]
+    MAX_RAIN[0] = 4.0
+    CONSISTENCY[0] = 64.0
+    ABSORBTION[0] = 0.6
+    YIELD_EST[0] = 0
+    TOTAL_RAIN[0] = 0
+    for DAY[0] in range(1, 31+1):
+        RAIN[0] = ((-((((DAY[0] - 16) ** 2) / CONSISTENCY[0])) + MAX_RAIN[0]) * ABSORBTION[0])
+        UPDATE_EST(RAIN, TOTAL_RAIN, YIELD_EST)
+        print("Day ", DAY, " Estimate: ", YIELD_EST)
+    print("Crop Yield(%): ", YIELD_EST)
+
+CROP_YIELD()

--- a/delphi/program_analysis/autoTranslate/pgm.json
+++ b/delphi/program_analysis/autoTranslate/pgm.json
@@ -1,0 +1,449 @@
+{
+  "dateCreated": "2018-07-22",
+  "functions": [
+    {
+      "body": [
+        {
+          "name": "UPDATE_EST__lambda__TOTAL_RAIN_0",
+          "reference": "4",
+          "type": "lambda"
+        }
+      ],
+      "name": "UPDATE_EST__assign__TOTAL_RAIN_0",
+      "sources": [
+        "TOTAL_RAIN",
+        "RAIN"
+      ],
+      "target": "TOTAL_RAIN",
+      "type": "assign"
+    },
+    {
+      "body": [
+        {
+          "name": "UPDATE_EST__lambda__IF_1_0",
+          "reference": "5",
+          "type": "lambda"
+        }
+      ],
+      "name": "UPDATE_EST__condition__IF_1_0",
+      "sources": [
+        "TOTAL_RAIN"
+      ],
+      "target": "IF_1",
+      "type": "assign"
+    },
+    {
+      "body": [
+        {
+          "name": "UPDATE_EST__lambda__YIELD_EST_0",
+          "reference": "6",
+          "type": "lambda"
+        }
+      ],
+      "name": "UPDATE_EST__assign__YIELD_EST_0",
+      "sources": [
+        "TOTAL_RAIN"
+      ],
+      "target": "YIELD_EST",
+      "type": "assign"
+    },
+    {
+      "body": [
+        {
+          "name": "UPDATE_EST__lambda__YIELD_EST_1",
+          "reference": "8",
+          "type": "lambda"
+        }
+      ],
+      "name": "UPDATE_EST__assign__YIELD_EST_1",
+      "sources": [
+        "TOTAL_RAIN"
+      ],
+      "target": "YIELD_EST",
+      "type": "assign"
+    },
+    {
+      "name": "UPDATE_EST__decision__YIELD_EST_0",
+      "sources": [
+        "IF_1_0",
+        "YIELD_EST_2",
+        "YIELD_EST_1"
+      ],
+      "target": "YIELD_EST",
+      "type": "assign"
+    },
+    {
+      "body": [
+        {
+          "input": [
+            {
+              "index": "0",
+              "variable": "TOTAL_RAIN"
+            },
+            {
+              "index": "0",
+              "variable": "RAIN"
+            }
+          ],
+          "name": "UPDATE_EST__assign__TOTAL_RAIN_0",
+          "output": {
+            "index": "1",
+            "variable": "TOTAL_RAIN"
+          }
+        },
+        {
+          "input": [
+            {
+              "index": "1",
+              "variable": "TOTAL_RAIN"
+            }
+          ],
+          "name": "UPDATE_EST__condition__IF_1_0",
+          "output": {
+            "index": "0",
+            "variable": "IF_1"
+          }
+        },
+        {
+          "input": [
+            {
+              "index": "1",
+              "variable": "TOTAL_RAIN"
+            }
+          ],
+          "name": "UPDATE_EST__assign__YIELD_EST_0",
+          "output": {
+            "index": "1",
+            "variable": "YIELD_EST"
+          }
+        },
+        {
+          "input": [
+            {
+              "index": "1",
+              "variable": "TOTAL_RAIN"
+            }
+          ],
+          "name": "UPDATE_EST__assign__YIELD_EST_1",
+          "output": {
+            "index": "2",
+            "variable": "YIELD_EST"
+          }
+        },
+        {
+          "input": [
+            {
+              "index": "0",
+              "variable": "IF_1"
+            },
+            {
+              "index": "2",
+              "variable": "YIELD_EST"
+            },
+            {
+              "index": "1",
+              "variable": "YIELD_EST"
+            }
+          ],
+          "name": "UPDATE_EST__decision__YIELD_EST_0",
+          "output": {
+            "index": "3",
+            "variable": "YIELD_EST"
+          }
+        }
+      ],
+      "input": [
+        {
+          "domain": "real",
+          "name": "RAIN"
+        },
+        {
+          "domain": "real",
+          "name": "TOTAL_RAIN"
+        },
+        {
+          "domain": "real",
+          "name": "YIELD_EST"
+        }
+      ],
+      "name": "UPDATE_EST",
+      "type": "container",
+      "variables": [
+        {
+          "domain": "real",
+          "name": "TOTAL_RAIN"
+        },
+        {
+          "domain": "real",
+          "name": "RAIN"
+        },
+        {
+          "domain": "boolean",
+          "name": "IF_1"
+        },
+        {
+          "domain": "real",
+          "name": "YIELD_EST"
+        }
+      ]
+    },
+    {
+      "body": {
+        "dtype": "real",
+        "type": "literal",
+        "value": "4.0"
+      },
+      "name": "CROP_YIELD__assign__MAX_RAIN_0",
+      "sources": [],
+      "target": "MAX_RAIN",
+      "type": "assign"
+    },
+    {
+      "body": {
+        "dtype": "real",
+        "type": "literal",
+        "value": "64.0"
+      },
+      "name": "CROP_YIELD__assign__CONSISTENCY_0",
+      "sources": [],
+      "target": "CONSISTENCY",
+      "type": "assign"
+    },
+    {
+      "body": {
+        "dtype": "real",
+        "type": "literal",
+        "value": "0.6"
+      },
+      "name": "CROP_YIELD__assign__ABSORBTION_0",
+      "sources": [],
+      "target": "ABSORBTION",
+      "type": "assign"
+    },
+    {
+      "body": {
+        "dtype": "integer",
+        "type": "literal",
+        "value": "0"
+      },
+      "name": "CROP_YIELD__assign__YIELD_EST_0",
+      "sources": [],
+      "target": "YIELD_EST",
+      "type": "assign"
+    },
+    {
+      "body": {
+        "dtype": "integer",
+        "type": "literal",
+        "value": "0"
+      },
+      "name": "CROP_YIELD__assign__TOTAL_RAIN_0",
+      "sources": [],
+      "target": "TOTAL_RAIN",
+      "type": "assign"
+    },
+    {
+      "body": [
+        {
+          "name": "CROP_YIELD__lambda__RAIN_0",
+          "reference": "24",
+          "type": "lambda"
+        }
+      ],
+      "name": "CROP_YIELD__assign__RAIN_0",
+      "sources": [
+        "DAY",
+        "CONSISTENCY",
+        "MAX_RAIN",
+        "ABSORBTION"
+      ],
+      "target": "RAIN",
+      "type": "assign"
+    },
+    {
+      "body": [
+        {
+          "input": [
+            {
+              "index": "-1",
+              "variable": "DAY"
+            },
+            {
+              "index": "-1",
+              "variable": "CONSISTENCY"
+            },
+            {
+              "index": "-1",
+              "variable": "MAX_RAIN"
+            },
+            {
+              "index": "-1",
+              "variable": "ABSORBTION"
+            }
+          ],
+          "name": "CROP_YIELD__assign__RAIN_0",
+          "output": {
+            "index": "0",
+            "variable": "RAIN"
+          }
+        },
+        {
+          "function": "UPDATE_EST",
+          "input": [
+            {
+              "index": "0",
+              "variable": "RAIN"
+            },
+            {
+              "index": "-1",
+              "variable": "TOTAL_RAIN"
+            },
+            {
+              "index": "-1",
+              "variable": "YIELD_EST"
+            }
+          ],
+          "output": {}
+        },
+        {
+          "function": "print",
+          "input": [
+            {
+              "index": "-1",
+              "variable": "DAY"
+            },
+            {
+              "index": "-1",
+              "variable": "YIELD_EST"
+            }
+          ],
+          "output": {}
+        }
+      ],
+      "index_iteration_range": {
+        "end": {
+          "dtype": "integer",
+          "type": "literal",
+          "value": "32"
+        },
+        "start": {
+          "dtype": "integer",
+          "type": "literal",
+          "value": "1"
+        }
+      },
+      "index_variable": "DAY",
+      "input": [
+        "CONSISTENCY",
+        "MAX_RAIN",
+        "ABSORBTION",
+        "RAIN",
+        "TOTAL_RAIN",
+        "YIELD_EST"
+      ],
+      "name": "CROP_YIELD__loop_plate__DAY_0",
+      "type": "loop_plate"
+    },
+    {
+      "body": [
+        {
+          "input": [],
+          "name": "CROP_YIELD__assign__MAX_RAIN_0",
+          "output": {
+            "index": "2",
+            "variable": "MAX_RAIN"
+          }
+        },
+        {
+          "input": [],
+          "name": "CROP_YIELD__assign__CONSISTENCY_0",
+          "output": {
+            "index": "2",
+            "variable": "CONSISTENCY"
+          }
+        },
+        {
+          "input": [],
+          "name": "CROP_YIELD__assign__ABSORBTION_0",
+          "output": {
+            "index": "2",
+            "variable": "ABSORBTION"
+          }
+        },
+        {
+          "input": [],
+          "name": "CROP_YIELD__assign__YIELD_EST_0",
+          "output": {
+            "index": "2",
+            "variable": "YIELD_EST"
+          }
+        },
+        {
+          "input": [],
+          "name": "CROP_YIELD__assign__TOTAL_RAIN_0",
+          "output": {
+            "index": "2",
+            "variable": "TOTAL_RAIN"
+          }
+        },
+        {
+          "inputs": [
+            "CONSISTENCY",
+            "MAX_RAIN",
+            "ABSORBTION",
+            "RAIN",
+            "TOTAL_RAIN",
+            "YIELD_EST"
+          ],
+          "name": "CROP_YIELD__loop_plate__DAY_0",
+          "output": {}
+        },
+        {
+          "function": "print",
+          "input": [
+            {
+              "index": "2",
+              "variable": "YIELD_EST"
+            }
+          ],
+          "output": {}
+        }
+      ],
+      "input": [],
+      "name": "CROP_YIELD",
+      "type": "container",
+      "variables": [
+        {
+          "domain": "integer",
+          "name": "DAY"
+        },
+        {
+          "domain": "real",
+          "name": "RAIN"
+        },
+        {
+          "domain": "real",
+          "name": "YIELD_EST"
+        },
+        {
+          "domain": "real",
+          "name": "TOTAL_RAIN"
+        },
+        {
+          "domain": "real",
+          "name": "MAX_RAIN"
+        },
+        {
+          "domain": "real",
+          "name": "CONSISTENCY"
+        },
+        {
+          "domain": "real",
+          "name": "ABSORBTION"
+        }
+      ]
+    }
+  ],
+  "name": "pgm.json",
+  "start": "CROP_YIELD"
+}

--- a/delphi/program_analysis/parse_dbn_json.py
+++ b/delphi/program_analysis/parse_dbn_json.py
@@ -1,30 +1,21 @@
-from os.path import join, normpath
+from os.path import normpath
 from pygraphviz import AGraph
 from typing import Dict
-import pprint
 import json
 
 import delphi.program_analysis.scopes as scp
 
 
 def main():
-    example_source_file = "crop_yield_DBN.json"
-    filepath = "../../data/program_analysis/pa_crop_yield_v0.2/"
-    dbn_json_source_file = normpath(join(filepath, example_source_file))
+    dbn_json_source_file = normpath("autoTranslate/pgm.json")
     data = read_dbn_from_json(dbn_json_source_file)
 
-    # print('DBN_JSON:')
-    # pprint.pprint(data)
-
     scope_tree = scp.scope_tree_from_json(data)
-
-    # g1 = setup_directed_graph()
-    # scope_tree.build_linked_graph(g1)
-    # g1.write("linked_graph.dot")
 
     g2 = setup_directed_graph()
     scope_tree.build_containment_graph(g2)
     g2.write("nested_graph.dot")
+    g2.draw("nested_graph.png", prog="dot")
 
 
 def read_dbn_from_json(dbn_json_source_file: str) -> Dict:


### PR DESCRIPTION
As opposed to using `python3.6` specifically in the autoTranslate script we should use `python3` so that 3.7 can be used to run `autoTranslate.sh`. I have tested this on my own system and was able to run the script with no errors when using `python3.7`. 

@stephensj2 does this change work for your system or do you require the use of `python3.6`?