### PR TITLE
Remove networkx version override

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Then pip install pipenv and do:
 
 ```bash
 pipenv install -d
-pipenv install networkx==2.1  # overrides NetworkX 1.11 (a dependency of INDRA)
 ```
 
 # Usage


### PR DESCRIPTION
This should no longer be needed since https://github.com/sorgerlab/indra/pull/404 is now merged.