### PR TITLE
Push test data target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - "3.6"
+  - "3.7"
 
 env:
   - DELPHI_DATA=$TRAVIS_BUILD_DIR/data

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ clean:
 pkg_lock:
 	pipenv lock
 	pipenv run pipenv_to_requirements
+
+push_test_data:
+	tar -zcvf delphi_data.tgz $(DELPHI_DATA) 
+	scp delphi_data.tgz adarsh@vision.cs.arizona.edu:public_html/delphi_data.tgz

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ pkg_lock:
 	pipenv run pipenv_to_requirements
 
 push_test_data:
-	tar -zcvf delphi_data.tgz $(DELPHI_DATA) 
+	tar -zcvf delphi_data.tgz  -C $(DELPHI_DATA)../ data
 	scp delphi_data.tgz adarsh@vision.cs.arizona.edu:public_html/delphi_data.tgz


### PR DESCRIPTION
This PR adds a target called `push_test_data` that automates the packaging and pushing of Delphi parameterization data to a server from which Travis CI can download it and use it in tests. It also adds Python 3.7 to the list of versions of Python for which to run tests.