### PR TITLE
Fixing tests

### DIFF
--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -48,21 +48,6 @@ s3 = Influence(
 
 sts = [s1, s2, s3]
 
-
-@pytest.fixture(scope="session")
-def test_statements_file():
-    return "test_statements.pkl"
-
-
-@pytest.fixture(scope="session")
-def test_model_file():
-    return "test_model.pkl"
-
-
-with open(test_statements_file(), "wb") as f:
-    pickle.dump(sts, f)
-
-
 @pytest.fixture(scope="session")
 def G():
     G = AnalysisGraph.from_statements(get_valid_statements_for_modeling(sts))

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -4,6 +4,7 @@ from indra.statements import Concept, Influence, Evidence
 from delphi.AnalysisGraph import AnalysisGraph
 from delphi.assembly import get_valid_statements_for_modeling
 
+
 conflict = Concept(
     "conflict",
     db_refs={

--- a/delphi/tests/test_AnalysisGraph.py
+++ b/delphi/tests/test_AnalysisGraph.py
@@ -29,22 +29,27 @@ def test_from_statements():
 
 
 def test_from_statements_file():
-    with open(test_statements_file(), "rb") as f:
+    test_statements_file = "test_statements.pkl"
+    with open(test_statements_file, "wb") as f:
+        pickle.dump(sts, f)
+
+    with open(test_statements_file, "rb") as f:
         sts_from_file = pickle.load(f)
     G = AnalysisGraph.from_statements(sts_from_file)
     assert set(G.nodes()) == set(["conflict", "food_security"])
     assert set(G.edges()) == set([("conflict", "food_security")])
-    os.remove(test_statements_file())
+    os.remove(test_statements_file)
 
 
-def test_from_pickle():
-    with open(test_model_file(), "wb") as f:
-        pickle.dump(G(), f)
-    with open(test_model_file(), "rb") as f:
+def test_from_pickle(G):
+    test_model_file = "test_model.pkl"
+    with open(test_model_file, "wb") as f:
+        pickle.dump(G, f)
+    with open(test_model_file, "rb") as f:
         M = pickle.load(f)
     assert set(M.nodes()) == set(["conflict", "food_security"])
     assert set(M.edges()) == set([("conflict", "food_security")])
-    os.remove(test_model_file())
+    os.remove(test_model_file)
 
 
 def test_get_subgraph_for_concept(G):


### PR DESCRIPTION
This PR modifies the test scripts so that pytest fixtures are not called directly, thus fixing failing tests on Travis.

@pauldhein FYI