### PR TITLE
Implement functionality to choose ICM REST service database with env variable

### DIFF
--- a/delphi/icm_api/config.py
+++ b/delphi/icm_api/config.py
@@ -10,7 +10,9 @@ BASE_DIR = Path(__file__).parent
 
 # Define the database - we are working with
 # SQLite for this example
-SQLALCHEMY_DATABASE_URI = f"sqlite:///{BASE_DIR}/delphi.db"
+SQLALCHEMY_DATABASE_URI = os.environ.get(
+    "SQLALCHEMY_DATABASE_URI", f"sqlite:///{BASE_DIR}/delphi.db"
+)
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 DATABASE_CONNECT_OPTIONS = {}
 


### PR DESCRIPTION
This PR implements the functionality to choose the database to be used with the ICM REST service with the environment variable `SQLALCHEMY_DATABASE_URI`