### PR TITLE
Update parameterization algorithm

### DIFF
--- a/delphi/AnalysisGraph.py
+++ b/delphi/AnalysisGraph.py
@@ -14,7 +14,7 @@ from indra.statements.evidence import Evidence
 from indra.sources.eidos import process_text
 from .random_variables import LatentVar, Indicator
 from .export import export_edge, _get_units, _get_dtype, _process_datetime
-from .utils.fp import flatMap, ltake, lmap, pairwise
+from .utils.fp import flatMap, take, ltake, lmap, pairwise
 from .paths import db_path
 from .db import engine
 from .assembly import (
@@ -55,7 +55,6 @@ class AnalysisGraph(nx.DiGraph):
     # ==========================================================================
     # Constructors
     # ==========================================================================
-
 
     @classmethod
     def from_statements_file(cls, file: str):
@@ -459,23 +458,41 @@ class AnalysisGraph(nx.DiGraph):
 
         mapping = construct_concept_to_indicator_mapping(n)
 
-        for n in self.nodes(data=True):
-            n[1]["indicators"] = get_indicators(n[0], mapping)
+        for node in self.nodes(data=True):
 
-    def parameterize(self, time: datetime):
+            # TODO Coordinate with Uncharted (Pascale) and CLULab (Becky) to
+            # make sure that the intervention nodes are represented consistently
+            # in the mapping (i.e. with spaces vs. with underscores.
+            if node[0].split("/")[1] == "interventions":
+                node_name = node[0].replace("_", " ")
+            else:
+                node_name = node[0]
+
+            results = engine.execute(
+                "select Indicator from concept_to_indicator_mapping where "
+                f"`Concept` like '{node_name}' and `source` like 'MITRE12'"
+            )
+
+            node[1]["indicators"] = {
+                x.split("/")[1]: Indicator(x.split("/")[1], "MITRE12")
+                for x in [r[0] for r in take(n, results)]
+            }
+
+    def parameterize(
+        self,
+        year: Optional[int] = None,
+        month: Optional[int] = None,
+        day: Optional[int] = None,
+    ):
         """ Parameterize the analysis graph.
 
         Args:
-            time
+            year
+            month
+            day
         """
 
-        nodes_with_indicators = [
-            n
-            for n in self.nodes(data=True)
-            if n[1].get("indicators") is not None
-        ]
-
-        for n in nodes_with_indicators:
+        for n in G.nodes(data=True):
             for indicator_name, indicator in n[1]["indicators"].items():
                 indicator.mean, indicator.unit = get_indicator_value(
                     indicator, time

--- a/delphi/assembly.py
+++ b/delphi/assembly.py
@@ -110,15 +110,16 @@ def get_best_match(indicator: Indicator, items: Iterable[str]) -> str:
 def get_indicator_value(
     indicator: Indicator, date: datetime
 ) -> Optional[float]:
-    """ Get the value of a particular indicator at a particular date and time. """
+    """ Get the value of a particular indicator at a particular date and time.
+    If no value is available, take historical average."""
 
-    variable_names = [
-        x[0]
-        for x in engine.execute(
-            f"select distinct `Variable` from indicator"
-        ).fetchall()
-    ]
-    best_match = get_best_match(indicator, variable_names)
+    # variable_names = [
+        # x[0]
+        # for x in engine.execute(
+            # f"select distinct `Variable` from indicator"
+        # ).fetchall()
+    # ]
+    # best_match = get_best_match(indicator, variable_names)
 
     # TODO Devise a strategy to get rid of the fetchone() call at the end of the
     # expression below (i.e. add month support instead of taking the first
@@ -127,7 +128,7 @@ def get_indicator_value(
     result = engine.execute(
         " ".join(
             [
-                f"select * from indicator where `Variable` like '{best_match}'",
+                f"select * from indicator where `Variable` like '{indicator.name}'",
                 "and `Value` is not null",
                 f"and `Year` is {date.year}",
             ]
@@ -171,21 +172,6 @@ def construct_concept_to_indicator_mapping(n: int = 1) -> Dict[str, List[str]]:
         for k, v in gb
     }
     return _dict
-
-
-def get_indicators(concept: str, mapping: Dict = None) -> Optional[List[str]]:
-    # TODO Coordinate with Uncharted (Pascale) and CLULab (Becky) to make sure
-    # that the intervention nodes are represented consistently in the mapping
-    # (i.e. with spaces vs. with underscores.
-
-    if concept.split("/")[1] == "interventions":
-        concept = concept.replace("_"," ")
-
-    return (
-        {x[0]: Indicator(x[0], x[1]) for x in mapping[concept]}
-        if concept in mapping
-        else None
-    )
 
 
 def make_edges(sts, node_permutations):

--- a/delphi/export.py
+++ b/delphi/export.py
@@ -91,7 +91,6 @@ def to_agraph(G, *args, **kwargs) -> AGraph:
 
     # Drawing indicator variables
 
-
     if kwargs.get("indicators"):
         for n in nodes_with_indicators:
             for indicator_name, ind in n[1]["indicators"].items():

--- a/delphi/random_variables.py
+++ b/delphi/random_variables.py
@@ -1,5 +1,5 @@
 import random
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Set
 from datetime import datetime
 from .db import engine
 
@@ -48,6 +48,7 @@ class Indicator(RV):
         value: float = None,
         stdev: float = None,
         time: datetime = None,
+        aggaxes: Set[str] = set(),
     ):
         super().__init__(name)
         self.source = source
@@ -56,6 +57,7 @@ class Indicator(RV):
         self.value = value
         self.stdev = stdev
         self.time = time
+        self.aggaxes = aggaxes
 
     def get_historical_distribution(
         self,

--- a/scripts/create_delphi_db.py
+++ b/scripts/create_delphi_db.py
@@ -53,7 +53,7 @@ def create_concept_to_indicator_mapping_table():
         },
     )
     df.Indicator = df.Indicator.str.replace("\\\/","/")
-    df.to_csv('test.csv')
+    df.to_csv('test.csv', index=False)
 
     insert_table(df, "concept_to_indicator_mapping")
 

--- a/scripts/create_delphi_db.py
+++ b/scripts/create_delphi_db.py
@@ -52,12 +52,14 @@ def create_concept_to_indicator_mapping_table():
             "Score": np.float64,
         },
     )
+    df.Indicator = df.Indicator.str.replace("\\\/","/")
+    df.to_csv('test.csv')
 
     insert_table(df, "concept_to_indicator_mapping")
 
 
 if __name__ == "__main__":
-    create_dssat_data_table()
-    create_indicator_table()
-    create_adjectiveData_table()
+    # create_dssat_data_table()
+    # create_indicator_table()
+    # create_adjectiveData_table()
     create_concept_to_indicator_mapping_table()

--- a/scripts/evaluations/month12/month12_script.py
+++ b/scripts/evaluations/month12/month12_script.py
@@ -145,6 +145,4 @@ def create_parameterized_CAG(filename = "CAG_with_indicators_and_values.pdf"):
 
 if __name__ == "__main__":
     os.makedirs("build", exist_ok=True)
-    create_quantified_CAG()
     create_CAG_with_indicators()
-    create_parameterized_CAG()

--- a/scripts/evaluations/month12/month12_script.py
+++ b/scripts/evaluations/month12/month12_script.py
@@ -10,17 +10,25 @@ from delphi.paths import data_dir
 from delphi.utils.indra import get_statements_from_json_file
 
 
+def create_pruned_corpus_json():
+    """ Prune the preassembled corpus json file """
+    with open(data_dir / "wm_12_month_4_reader_20190118.json", "r") as f:
+        sts = json.load(f)
+    filtered_sts = []
+    for s in sts:
+        if s["type"] == "Influence":
+            for c in (s['subj'], s['obj']):
+                for key in [k for k in c['db_refs'] if k != "UN"]:
+                    del c['db_refs'][key]
+
+            filtered_sts.append(s)
+    with open("build/pruned_corpus.json", "w") as f:
+        f.write(json.dumps(filtered_sts, indent=2))
+
 def get_all_sts():
     """ Get all preassembled statements, prune away unneeded information, pickle
     them. """
-    all_sts = get_statements_from_json_file(
-        data_dir / "wm_12_month_4_reader_20190118.json"
-    )
-    for s in all_sts:
-        for c in (s.subj, s.obj):
-            for key in [k for k in c.db_refs if k != "UN"]:
-                del c.db_refs[key]
-
+    all_sts = get_statements_from_json_file("build/pruned_corpus.json")
     with open("build/all_sts.pkl", "wb") as f:
         pickle.dump(all_sts, f)
 
@@ -107,32 +115,33 @@ def create_precipitation_centered_CAG(filename="CAG.pdf"):
     G = G.get_subgraph_for_concept(
         "UN/events/weather/precipitation", depth=2, flow="outgoing"
     )
-    G.prune(cutoff=2)
+    G.prune(cutoff=0)
     A = to_agraph(G)
     A.graph_attr["rankdir"] = "TB"
     A.draw(filename, prog="dot")
     with open("build/precipitation_centered_CAG.pkl", "wb") as f:
         pickle.dump(G, f)
 
-
-def create_quantified_CAG():
-    with open("build/precipitation_centered_CAG.pkl", "rb") as f:
-        G = pickle.load(f)
-    G.res = 500
-    G.assemble_transition_model_from_gradable_adjectives()
-    G.sample_from_prior()
-    with open("build/quantified_CAG.pkl", "wb") as f:
-        pickle.dump(G, f)
-
 def create_CAG_with_indicators(filename="CAG_with_indicators.pdf"):
     """ Create a CAG with mapped indicators """
-    with open("build/quantified_CAG.pkl", "rb") as f:
+    with open("build/precipitation_centered_CAG.pkl", "rb") as f:
         G = pickle.load(f)
     G.map_concepts_to_indicators()
     A = to_agraph(G, indicators=True)
     A.draw(filename, prog="dot")
     with open("build/CAG_with_indicators.pkl", "wb") as f:
         pickle.dump(G, f)
+
+def create_quantified_CAG():
+    with open("build/CAG_with_indicators.pkl", "rb") as f:
+        G = pickle.load(f)
+
+    G.res = 500
+    G.assemble_transition_model_from_gradable_adjectives()
+    G.sample_from_prior()
+    with open("build/quantified_CAG.pkl", "wb") as f:
+        pickle.dump(G, f)
+
 
 
 def create_parameterized_CAG(filename = "CAG_with_indicators_and_values.pdf"):
@@ -145,4 +154,10 @@ def create_parameterized_CAG(filename = "CAG_with_indicators_and_values.pdf"):
 
 if __name__ == "__main__":
     os.makedirs("build", exist_ok=True)
-    create_CAG_with_indicators()
+    # create_pruned_corpus_json()
+    # get_all_sts()
+    # create_reference_CAG()
+    create_precipitation_centered_CAG()
+    # create_quantified_CAG()
+    # create_CAG_with_indicators()
+    # create_parameterized_CAG()

--- a/scripts/evaluations/month12/month12_script.py
+++ b/scripts/evaluations/month12/month12_script.py
@@ -115,7 +115,7 @@ def create_precipitation_centered_CAG(filename="CAG.pdf"):
     G = G.get_subgraph_for_concept(
         "UN/events/weather/precipitation", depth=2, flow="outgoing"
     )
-    G.prune(cutoff=0)
+    G.prune(cutoff=2)
     A = to_agraph(G)
     A.graph_attr["rankdir"] = "TB"
     A.draw(filename, prog="dot")
@@ -142,13 +142,11 @@ def create_quantified_CAG():
     with open("build/quantified_CAG.pkl", "wb") as f:
         pickle.dump(G, f)
 
-
-
 def create_parameterized_CAG(filename = "CAG_with_indicators_and_values.pdf"):
     """ Create a CAG with mapped and parameterized indicators """
-    with open("build/CAG_with_indicators.pkl", "rb") as f:
+    with open("build/quantified_CAG.pkl", "rb") as f:
         G = pickle.load(f)
-    G.parameterize(datetime(2017,4,1))
+    G.parameterize(year = 2017, month = 4)
     A = to_agraph(G, indicators=True, indicator_values=True)
     A.draw(filename, prog="dot")
 
@@ -157,7 +155,7 @@ if __name__ == "__main__":
     # create_pruned_corpus_json()
     # get_all_sts()
     # create_reference_CAG()
-    create_precipitation_centered_CAG()
-    # create_quantified_CAG()
-    # create_CAG_with_indicators()
-    # create_parameterized_CAG()
+    # create_precipitation_centered_CAG()
+    create_CAG_with_indicators()
+    create_quantified_CAG()
+    create_parameterized_CAG()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,6 @@ def G():
     G.assemble_transition_model_from_gradable_adjectives()
     G.sample_from_prior()
     G.map_concepts_to_indicators()
-    G.parameterize(date(2014, 12, 1))
+    G.parameterize(year = 2014, month = 12)
     G.to_pickle()
     yield G

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -82,8 +82,6 @@ def test_contains_relevant_concept():
 
 def test_get_indicator_data():
     indicator = Indicator(
-        "Political stability and absence of violence/terrorism (index), Value",
-        "WB",
+        "Value, Political stability and absence of violence/terrorism (index)"
     )
-    t = datetime(2012, 1, 1)
-    assert get_indicator_value(indicator, t)[0] == -1.2
+    assert get_indicator_value(indicator, year = 2012, month = 1)[0] == -1.884


### PR DESCRIPTION
This PR implements an updated parameterization algorithm for the AnalysisGraph that, upon not finding exact matches for particular set of parameterization constraints, goes through a user-configurable list of 'axes' (with some sensible defaults - `["year", "month"]`) until it finds matches, and then aggregates them according to a user-specifiable aggregation function (defaults to numpy.mean). It also deals with the case where there are multiple indicators with the same name, but different units.

This should ensure that none of the indicator means turn out to be null.