### PR TITLE
Switching from ReadTheDocs to Travis CI for building and deploying docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ deploy:
   provider: pages
   skip-cleanup: true
   github-token: $GITHUB_TOKEN
-  keep-history: true
   on:
-    branch: travis_docs
+    branch: master
+
 after_success: coveralls
+
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,17 @@ install:
   - pip install .[test]
   - wget http://vision.cs.arizona.edu/adarsh/delphi.db
 
-script: make test
+script:
+  - make test
+  - cd docs; make apidocs; make html
+
+deploy:
+  local-dir: docs/build/html
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: true
+  on:
+    branch: master
 after_success: coveralls
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 install:
   - pip install git+https://github.com/sorgerlab/indra.git
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
-  - pip install .[test]
+  - pip install .[test,docs]
   - wget http://vision.cs.arizona.edu/adarsh/delphi.db
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,12 @@ script:
   - cd docs; make apidocs; make html
 
 deploy:
-  local-dir: docs/build/html
+  local-dir: docs/_build/html
   provider: pages
   skip-cleanup: true
   github-token: $GITHUB_TOKEN
   keep-history: true
   on:
-    branch: master
+    branch: travis_docs
 after_success: coveralls
 cache: pip


### PR DESCRIPTION
This PR implements a switch away from ReadTheDocs to using Travis CI to build and deploy Delphi API documentation. The reason for this switch is that build process in RTD is very constrained and breaks often. It also requires a separate requirements.txt file for non PyPI-based Python package installs, and is just frequently a PITA in general.

The new home of Delphi documentation is now https://ml4ai.github.io/delphi/

S/O to @jpfairbanks and the [SemanticModels](https://github.com/jpfairbanks/SemanticModels.jl) team - this was inspired by their recent documentation building updates.