### PR TITLE
Format

### DIFF
--- a/delphi/translators/for2py/scripts/fortran_format.py
+++ b/delphi/translators/for2py/scripts/fortran_format.py
@@ -94,6 +94,7 @@ class Format:
         self._out_widths = [sub[2] for sub in output_info if sub[2] is not None]
         self._write_line_init = True
 
+
     def read_line(self, line):
         """
         Match a line of input according to the format specified and return a
@@ -143,6 +144,10 @@ class Format:
 
         if not self._write_line_init:
             self.init_write_line()
+
+        if len(self._out_widths) > len(values):
+            sys.stderr.write(f"ERROR: too few values for format {self._format_list}\n")
+            sys.exit(1)
 
         out_strs = []
         for i in range(len(self._out_widths)):

--- a/tests/data/arrays/arrays-basic-08.f
+++ b/tests/data/arrays/arrays-basic-08.f
@@ -30,7 +30,7 @@ C END INITIALIZATION
  12   FORMAT(/,' AUGMENTED MATRIX',/)
       WRITE(*,12)
 
-61    FORMAT(5(1X,5f8.4))
+61    FORMAT(5(1X,f8.4))
       DO I=1,N
       WRITE(*, 61) A(I,1), A(I,2), A(I,3), A(I,4), A(I,5)
       END DO


### PR DESCRIPTION
Fixed a typo in arrays-basic-08.f that was causing a crash in `fortran_format.py`.  Added a check in `fortran_format.py` to detect the problem and die gracefully.