### PR TITLE
Bugfix for Delphi REST API createNewICM endpoint

### DIFF
--- a/delphi/AnalysisGraph.py
+++ b/delphi/AnalysisGraph.py
@@ -35,7 +35,6 @@ from .utils.indra import (
     get_statements_from_json_list,
     get_statements_from_json_file,
 )
-from .paths import db_path
 from .db import engine
 from .assembly import (
     constructConditionalPDF,

--- a/delphi/icm_api/config.py
+++ b/delphi/icm_api/config.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from pathlib import Path
+from delphi.paths import db_path
 
 # Statement for enabling the development environment
 DEBUG = True
@@ -9,7 +10,7 @@ BASE_DIR = Path(__file__).parent
 
 # Define the database - we are working with
 # SQLite for this example
-SQLALCHEMY_DATABASE_URI = f"sqlite:////var/www/html/delphi.db"
+SQLALCHEMY_DATABASE_URI = f"sqlite:///{db_path}"
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 DATABASE_CONNECT_OPTIONS = {}
 

--- a/delphi/icm_api/setup_sista_vm.sh
+++ b/delphi/icm_api/setup_sista_vm.sh
@@ -1,4 +1,9 @@
 # Script to setup AutoMATES and Delphi webapps on SISTA VM
+# This script has not been adequately tested - run at your own risk!
+# (Perhaps try running line by line if you haven't run the whole thing before)
+# TODO Convert this into a README instead - too dangerous to let it live as a
+# script.
+# TODO Add proper instructions about chowning etc.
 
 cd
 sudo apt-get install vim
@@ -22,5 +27,8 @@ cd automates/demo
 pip install -r requirements.txt
 sudo ln -sfT ~/automates/demo /var/www/html/automates_demo
 sudo ln -sfT ~/delphi /var/www/html/delphi
+sudo mkdir /var/www/html/delphi_data
+cd /var/www/html/delphi_data
 wget http://vision.cs.arizona.edu/adarsh/delphi.db
-sudo ln -sfT ~/delphi.db /var/www/html/delphi.db
+cd
+sudo chown -R www-data:www-data /var/www/html/delphi_data

--- a/delphi/paths.py
+++ b/delphi/paths.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import json
 
 data_dir = Path(os.environ.get("DELPHI_DATA", ""))
-db_path = Path(os.environ.get("DELPHI_DB", ""))
+db_path = Path(os.environ.get("DELPHI_DB", "/var/www/html/delphi_data/delphi.db"))
 
 adjectiveData = data_dir / "adjectiveData.tsv"
 south_sudan_data = data_dir / "south_sudan_data.csv"


### PR DESCRIPTION
This PR fixes the issue of the Delphi REST API not allowing POST requests (GET requests worked fine).

For posterity: the path to the DB was set separately in `delphi/db.py` and `delphi/icm_api/config.py` allowing them to get out of sync. This PR makes it so that the DB path is set to the environment variable `DELPHI_DB` while running locally, and is set to the correct path on the `vanga.sista.arizona.edu` VM when deployed in production.

@fhusainUC: Once this is merged into master, please take the REST API for a spin with CauseMos and CauseWorks to see if things work as expected (http://vanga.sista.arizona.edu/delphi/icm).