### PR TITLE
Program analysis graph wiring update

### DIFF
--- a/delphi/GrFN/scopes.py
+++ b/delphi/GrFN/scopes.py
@@ -408,7 +408,7 @@ class Node(metaclass=ABCMeta):
         return f"{self.name}_{self.index}__{self.scope}"
 
     def get_label(self):
-        return self.name
+        return '_'.join((self.name, str(self.index)))
 
 
 class FuncVariableNode(Node):


### PR DESCRIPTION
This PR implements a wiring update so that a CAG is produced with the right link structure from the simple Fortran program below:

```fortran
      program main
      implicit none
      integer i, x, y
      x = 1
      y = 0

      if (x .eq. 1) then
          y = 1
      end if

      end program main
```

The resulting computation graph and CAG are shown below:

<img width="441" alt="screen shot 2019-02-21 at 12 10 32 pm" src="https://user-images.githubusercontent.com/653549/53194909-be615e80-35d1-11e9-92b9-bcf45d247064.png">

<img width="99" alt="screen shot 2019-02-21 at 12 11 06 pm" src="https://user-images.githubusercontent.com/653549/53194924-c9b48a00-35d1-11e9-95b7-0a199a309a20.png">

FYI @skdebray 