### PR TITLE
Removing functions from sources in GrFN JSON

### DIFF
--- a/delphi/translators/for2py/scripts/genPGM.py
+++ b/delphi/translators/for2py/scripts/genPGM.py
@@ -209,7 +209,8 @@ def make_fn_dict(name, target, sources, lambdaName, node):
             if src["call"]["function"] == "Format":
                 return fn
             for source_ins in make_call_body_dict(src):
-                source.append(source_ins)
+                if source_ins["type"] != "function":
+                    source.append(source_ins)
         if "var" in src:
             variable = src["var"]["variable"]
             source.append({"name": variable, "type": "variable"})


### PR DESCRIPTION
This PR implements a fix for functions appearing as sources in parts of the GrFN JSON (#187) 