### PR TITLE
Switching to Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ deploy:
   on:
     branch: master
 
-after_success: coveralls
+after_success: bash <(curl -s https://codecov.io/bash)
 
 cache: pip

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
             "pytest-cov",
             "pytest-sugar",
             "pytest-xdist",
-            "coveralls",
             "mypy",
         ],
         "docs": [


### PR DESCRIPTION
This PR implements switching away from Coveralls to Codecov due to problems with Coveralls integration.