### PR TITLE
For2Py custom exception class

### DIFF
--- a/delphi/translators/for2py/__init__.py
+++ b/delphi/translators/for2py/__init__.py
@@ -1,0 +1,15 @@
+class For2PyError(Exception):
+    status_code=400
+
+    def __init__(self, message, status_code=None, payload=None):
+        Exception.__init__(self)
+
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        self.payload = payload
+
+    def to_dict(self):
+        rv = dict(self.payload or ())
+        rv['message'] = f"For2Py error: {self.message}"
+        return rv

--- a/delphi/translators/for2py/arrays.py
+++ b/delphi/translators/for2py/arrays.py
@@ -9,6 +9,7 @@
 import copy
 import itertools
 import sys
+from . import For2PyError
 
 _GET_ = 0
 _SET_ = 1
@@ -36,8 +37,7 @@ class Array:
             the size specified by the bounds with each element set to the value
             None."""
         if len(bounds) == 0:
-            sys.stderr.write("Zero-length arrays current not handled!\n")
-            sys.exit(1)
+            raise For2PyError("Zero-length arrays current not handled!.")
 
         this_dim = bounds[0]
         lo,hi = this_dim[0],this_dim[1]
@@ -94,8 +94,7 @@ class Array:
             subs = (subs,)
 
         if len(subs) == 0:
-            sys.stderr.write("Zero-length arrays currently not handled\n")
-            sys.exit(1)
+            raise For2PyError("Zero-length arrays currently not handled.")
 
         bounds = self._bounds
         sub_arr = self._values

--- a/delphi/translators/for2py/format.py
+++ b/delphi/translators/for2py/format.py
@@ -50,6 +50,7 @@ Usage:
 """
 
 import re, sys
+from . import For2PyError
 
 
 class Format:
@@ -125,11 +126,11 @@ class Format:
                     val = int(match_str)
                 else:
                     sys.stderr.write(
-                        "Unrecognized conversion function: {}\n".format(cvt_fn)
+                        f"Unrecognized conversion function: {cvt_fn}\n"
                     )
             else:
                 sys.stderr.write(
-                    "Format conversion failed: {}\n".format(match_str)
+                    f"Format conversion failed: {match_str}\n"
                 )
 
             matched_values.append(val)
@@ -146,8 +147,7 @@ class Format:
             self.init_write_line()
 
         if len(self._out_widths) > len(values):
-            sys.stderr.write(f"ERROR: too few values for format {self._format_list}\n")
-            sys.exit(1)
+            raise For2PyError(f"ERROR: too few values for format {self._format_list}\n")
 
         out_strs = []
         for i in range(len(self._out_widths)):
@@ -248,10 +248,9 @@ class Format:
                 rexp1 = leading_sp + optional_sign + rexp0  # r.e. for matching
                 rexp = [(xtract_rexp, rexp1, divisor, "float")]
             else:
-                sys.stderr.write(
-                    "ERROR: Unrecognized format specifier {}\n".format(fmt)
+                raise For2PyError(
+                    f"ERROR: Unrecognized format specifier {fmt}\n"
                 )
-                sys.exit(1)
 
         # replicate the regular expression by the repetition factor in the format
         rexp *= reps
@@ -327,7 +326,7 @@ class Format:
                 # the exponent width -- but if it's there, we need to extract
                 # the sequence of digits before it.
                 m = re.match("(\d+).*", suffix)
-                assert m is not None, 'Improper format? "{}"'.format(fmt)
+                assert m is not None, f"Improper format? '{fmt}'"
                 prec = m.group(1)
                 gen_fmt = "{}"
                 cvt_fmt = "{:" + sz + "." + prec + fmt[0] + "}"
@@ -349,10 +348,9 @@ class Format:
                 rexp = [(gen_fmt, None, None)]
 
             else:
-                sys.stderr.write(
-                    "ERROR: Unrecognized format specifier {}\n".format(fmt)
+                raise For2PyError(
+                    f"ERROR: Unrecognized format specifier {fmt}\n"
                 )
-                sys.exit(1)
 
         # replicate the regular expression by the repetition factor in the format
         rexp *= reps
@@ -486,11 +484,11 @@ def example_1():
     rexp1 = Format(format1)
     (DATE, SRAD, TMAX, TMIN, RAIN, PAR) = rexp1.read_line(input1)
 
-    print("FORMAT: {}".format(format1))
-    print('regexp_str = "{}"'.format(rexp1))
+    print(f"FORMAT: {format1}")
+    print(f"regexp_str = '{rexp1}'")
 
     vars1 = (DATE, SRAD, TMAX, TMIN, RAIN, PAR)
-    print("vars1 = {}".format(vars1))
+    print(f"vars1 = {vars1}")
     print("")
 
 

--- a/delphi/translators/for2py/genCode.py
+++ b/delphi/translators/for2py/genCode.py
@@ -1,5 +1,6 @@
 import ast
 import sys
+from . import For2PyError
 
 
 class PrintState:
@@ -170,8 +171,7 @@ def genCode(node, state):
     # Subscript: ('value', 'slice', 'ctx')
     elif isinstance(node, ast.Subscript):
         if not isinstance(node.slice.value, ast.Num):
-            sys.stderr.write("can't handle arrays in genCode right now\n")
-            sys.exit(1)
+            raise For2PyError("can't handle arrays in genCode right now.")
         # typical:
         # codeStr = '{0}{1}'.format(genCode(node.value, state), genCode(node.slice, state))
         codeStr = genCode(node.value, state)

--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -9,7 +9,7 @@ import argparse
 from functools import reduce
 import json
 from delphi.translators.for2py.genCode import genCode, PrintState
-from delphi.translators.for2py import For2PyError
+from . import For2PyError
 from typing import List, Dict, Iterable, Optional
 from itertools import chain, product
 import operator
@@ -134,11 +134,11 @@ class GrFNGenerator(object):
 
         # Load: ()
         elif isinstance(node, ast.Load):
-            raise For2PyError("Found ast.Load, which should not happen")
+            raise For2PyError("Found ast.Load, which should not happen.")
 
         # Store: ()
         elif isinstance(node, ast.Store):
-            raise For2PyError("Found ast.Store, which should not happen\n")
+            raise For2PyError("Found ast.Store, which should not happen.")
 
         # Index: ('value',)
         elif isinstance(node, ast.Index):
@@ -165,11 +165,11 @@ class GrFNGenerator(object):
         # For: ('target', 'iter', 'body', 'orelse')
         elif isinstance(node, ast.For):
             if self.genPgm(node.orelse, state, fnNames, "for"):
-                raise For2PyError("For/Else in for not supported\n")
+                raise For2PyError("For/Else in for not supported.")
 
             indexVar = self.genPgm(node.target, state, fnNames, "for")
             if len(indexVar) != 1 or "var" not in indexVar[0]:
-                raise For2PyError("Only one index variable is supported\n")
+                raise For2PyError("Only one index variable is supported.")
             indexName = indexVar[0]["var"]["variable"]
 
             loopIter = self.genPgm(node.iter, state, fnNames, "for")
@@ -178,7 +178,7 @@ class GrFNGenerator(object):
                 or "call" not in loopIter[0]
                 or loopIter[0]["call"]["function"] != "range"
             ):
-                raise For2PyError("Can only iterate over a range\n")
+                raise For2PyError("Can only iterate over a range.")
 
             rangeCall = loopIter[0]["call"]
             if (
@@ -194,7 +194,7 @@ class GrFNGenerator(object):
                     and rangeCall["inputs"][1]["type"] == "literal"
                 )
             ):
-                raise For2PyError("Can only iterate over a constant range\n")
+                raise For2PyError("Can only iterate over a constant range.")
 
             iterationRange = {
                 "start": rangeCall["inputs"][0][0],
@@ -597,11 +597,11 @@ class GrFNGenerator(object):
                                 body["input"].append(arg[0]["var"])
                         else:
                             raise For2PyError(
-                                "Only 1 input per argument supported right now\n"
+                                "Only 1 input per argument supported right now."
                             )
                     pgm["body"].append(body)
                 else:
-                    raise For2PyError(f"Unsupported expr: {expr}\n")
+                    raise For2PyError(f"Unsupported expr: {expr}.")
             return [pgm]
 
         # Compare: ('left', 'ops', 'comparators')
@@ -613,7 +613,7 @@ class GrFNGenerator(object):
         # Subscript: ('value', 'slice', 'ctx')
         elif isinstance(node, ast.Subscript):
             if not isinstance(node.slice.value, ast.Num):
-                raise For2PyError("can't handle arrays right now\n")
+                raise For2PyError("can't handle arrays right now.")
 
             val = self.genPgm(node.value, state, fnNames, "subscript")
 
@@ -1025,7 +1025,7 @@ def getVarType(annNode):
                 "supported as of now).\n"
             )
     except AttributeError:
-        raise For2PyError("Unsupported type (annNode is None).\n")
+        raise For2PyError("Unsupported type (annNode is None).")
 
 
 def getDType(val):
@@ -1036,7 +1036,7 @@ def getDType(val):
     elif isinstance(val, str):
         dtype = "string"
     else:
-        raise For2PyError(f"num: {type(val)}\n")
+        raise For2PyError(f"num: {type(val)}.")
     return dtype
 
 

--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -23,6 +23,7 @@ import argparse
 import re
 from typing import Dict
 from delphi.translators.for2py.format import list_data_type
+from . import For2PyError
 
 
 class PrintState:
@@ -339,8 +340,7 @@ class PythonCodeGenerator(object):
         elif node["type"].upper() == "CHARACTER":
             varType = "str"
         else:
-            print(f"unrecognized type {node['type']}")
-            sys.exit(1)
+            raise For2PyError(f"unrecognized type {node['type']}")
         if node["arg_type"] == "arg_array":
             self.pyStrings.append(f"{self.nameMapper[node['name']]}")
         else:
@@ -377,8 +377,7 @@ class PythonCodeGenerator(object):
                     initVal = init_val if initial_set else 0
                     varType = node["type"]
                 else:
-                    print(f"unrecognized type {node['type']}")
-                    sys.exit(1)
+                    raise For2PyError(f"unrecognized type {node['type']}")
 
             if "isDevTypeVar" in node and node["isDevTypeVar"]:
                 self.pyStrings.append(


### PR DESCRIPTION
This PR adds a custom exception class for for2py, `For2PyError`.

So instead of writing

```python
sys.stderr.write("Zero-length arrays current not handled!\n")
sys.exit(1)
```

you would now write

```python
raise For2PyError("Zero-length arrays current not handled!")
```

This exception will then be propagated to the CodeExplorer webapp.

To test this out, grab the latest master branches of the Delphi and automates repos and run the webapp locally (I won't be deploying this to http://vanga.sista.arizona.edu/automates until issue #211 is resolved - there are still some wiring issues).

Here's a preview of how the errors will appear:

<img width="498" alt="Screen Shot 2019-03-20 at 3 21 00 PM" src="https://user-images.githubusercontent.com/653549/54723142-d3270880-4b23-11e9-9c82-077888b52f33.png">

This will work for error messages up to 4000 characters long. If you would like longer error messages, let me know and I can implement that.