### PR TITLE
Updates to documentation, new GrFN constructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,15 @@ language: python
 python:
   - "3.6"
 
-env:
-  - DELPHI_DB=$TRAVIS_BUILD_DIR/delphi.db
-
 addons:
   apt:
     packages:
     - graphviz
 
 install:
-  - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
-  - pip install .[test,docs]
-  - wget http://vision.cs.arizona.edu/adarsh/delphi.db
+  - pip install -e .[test,docs]
+  - curl -O http://vision.cs.arizona.edu/adarsh/delphi.db
+  - export DELPHI_DB=`pwd`/delphi.db
 
 script:
   - make test

--- a/delphi/GrFN/analysis.py
+++ b/delphi/GrFN/analysis.py
@@ -9,8 +9,7 @@ def get_S2_ranks(S2_mat):
 
 def get_min_s2_sensitivity(S2_mat):
     """
-    Returns a tuple of the form:
-        (S2-value, variable index 1, variable index 2)
+    Returns a tuple of the form: (S2-value, variable index 1, variable index 2)
     where S2-value is the minimum of the set of all S2 indices
     """
     return min(get_S2_ranks(S2_mat), key=lambda tup: abs(tup[0]))
@@ -18,8 +17,7 @@ def get_min_s2_sensitivity(S2_mat):
 
 def get_max_s2_sensitivity(S2_mat):
     """
-    Returns a tuple of the form:
-        (S2-value, variable index 1, variable index 2)
+    Returns a tuple of the form: (S2-value, variable index 1, variable index 2)
     where S2-value is the maximum of the set of all S2 indices
     """
     return max(get_S2_ranks(S2_mat), key=lambda tup: abs(tup[0]))

--- a/delphi/GrFN/networks.py
+++ b/delphi/GrFN/networks.py
@@ -384,6 +384,8 @@ class GroundedFunctionNetwork(ComputationalGraph):
         lambdas = importlib.__import__(stem + "_lambdas")
         return cls.from_dict(pgm_dict, lambdas)
 
+
+
     @classmethod
     def from_fortran_file(cls, fortran_file: str, tmpdir: str = "."):
         """Builds GrFN object from a Fortran program."""
@@ -420,6 +422,27 @@ class GroundedFunctionNetwork(ComputationalGraph):
         pySrc = pyTranslate.create_python_source_list(outputDict)[0][0]
 
         G = cls.from_python_src(pySrc, lambdas_path, json_filename, stem)
+        return G
+
+    @classmethod
+    def from_fortran_src(cls, fortran_src: str, dir: str = "."):
+        """ Create a GroundedFunctionNetwork instance from a string with raw
+        Fortran code.
+
+        Args:
+            fortran_src: A string with Fortran source code.
+            dir: (Optional) - the directory in which the temporary Fortran file
+                will be created (make sure you have write permission!) Defaults to
+                the current directory.
+        Returns:
+            A GroundedFunctionNetwork instance
+        """
+        import tempfile
+        fp = tempfile.NamedTemporaryFile('w+t', delete=False, dir=dir)
+        fp.writelines(fortran_src)
+        fp.close()
+        G = cls.from_fortran_file(fp.name, dir)
+        os.remove(fp.name)
         return G
 
     def clear(self):

--- a/docs/AnalysisGraph_API.rst
+++ b/docs/AnalysisGraph_API.rst
@@ -25,6 +25,8 @@ values of the dictionary are objects of the class
 
 The methods listed on this page constitute the public API for Delphi.
 
+.. autoclass:: AnalysisGraph
+
 Constructors
 ------------
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 Contributing
 ============
 
-Workflow
---------
+Suggested Git Workflow
+----------------------
 
-The following contribution workflow is suggested. To implement a new feature, do
-the following:
+The following git workflow is suggested for contributors. To implement a new
+feature, do the following:
 
 - Assuming you are on the `master` branch, check out a new feature branch. If
   the name of the feature is `new_feature`, you would do `git checkout -b new_feature`.
@@ -78,3 +78,37 @@ the following:
 - Committing changes directly to the `master` branch is *highly* discouraged.
   The only exception to this rule is documentation updates (updating READMEs,
   etc.) And even then, major documentation updates should be done via a PR.
+
+Running tests locally
+---------------------
+
+To run the complete test suite, invoke the following command from the Delphi
+repo root directory.
+
+```
+make test
+```
+
+To run a particular test module, e.g. `test_program_analysis.py`, invoke the
+following command instead:
+
+```
+pytest tests/test_program_analysis.py
+```
+
+To run a particular testing function within a test module, e.g. the
+`test_petpt_grfn_generation` test function in `test_program_analysis.py`,
+invoke the following instead:
+
+```
+pytest tests/test_program_analysis.py -k test_petpt_grfn_generation
+```
+
+If you would like the output of print statements (either in the library code or
+the testing code) to be displayed instead of suppressed, pass the `-s` flag to
+the `pytest` invocation:
+
+```
+pytest -s tests/test_program_analysis.py
+```
+suppressed

--- a/docs/GrFN_API.rst
+++ b/docs/GrFN_API.rst
@@ -17,6 +17,7 @@ Constructors
 .. autosummary:: 
     :toctree: generated/
 
+    GroundedFunctionNetwork.from_fortran_src
     GroundedFunctionNetwork.from_fortran_file
     GroundedFunctionNetwork.from_python_src
     GroundedFunctionNetwork.from_python_file

--- a/docs/GrFN_API.rst
+++ b/docs/GrFN_API.rst
@@ -10,10 +10,12 @@ information about computational relationships between variables in code.
 Additionally, the ForwardInfluenceBlanket class is provided to facilitate model
 comparison
 
+.. currentmodule:: delphi.GrFN.networks
+.. autoclass:: GroundedFunctionNetwork
+
 Constructors
 ------------
 
-.. currentmodule:: delphi.GrFN.networks
 .. autosummary:: 
     :toctree: generated/
 
@@ -24,7 +26,6 @@ Constructors
 
 Export
 ------
-.. currentmodule:: delphi.GrFN.networks
 .. autosummary::
     :toctree: generated/
 
@@ -34,7 +35,6 @@ Export
 
 Execution
 ---------
-.. currentmodule:: delphi.GrFN.networks
 .. autosummary::
     :toctree: generated/
 
@@ -42,7 +42,6 @@ Execution
 
 Model Analysis
 --------------
-.. currentmodule:: delphi.GrFN.networks
 .. autosummary::
     :toctree: generated/
 
@@ -50,13 +49,11 @@ Model Analysis
 
 Sensitivity Analysis
 --------------------
-.. currentmodule:: delphi.GrFN.networks
 .. autosummary::
     :toctree: generated/
 
     GroundedFunctionNetwork.S2_surface
 
-.. currentmodule:: delphi.GrFN.networks
 .. autosummary::
     :toctree: generated/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,10 +21,7 @@ import os
 import sys
 from unittest.mock import MagicMock
 #from mock import MagicMock
-sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../'))
-sys.path.insert(0, os.path.abspath('../../'))
-autodoc_mock_imports = ["indra"]
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,52 +1,53 @@
 # Installation
 
-Delphi is under active development in an academic, rather than a
-commercial setting, so we do not have the resources to test it out on
-the Windows operating system, or provide a one-step/one-click setup
-process.
+## Prerequisites
 
-That being said, this is a Python package, and we use
-platform-independent path handling internally within the code using
-`pathlib`, so *technically*, it should work fine on Windows machines
-as well, and we will try to guide you through the installation process
-as much as possible. Pull requests for improvements are always
-welcome.
+The following are the prerequisites for Delphi:
 
-The following are the requirements for Delphi:
-
-- Python 3.6 or higher.
-
-  - Python 3.6 is recommended.
-
+- Python 3.6+ and pip
 - [Graphviz](https://www.graphviz.org/download/) - Delphi uses this to
   visualize causal analysis graphs. See MacOS and Ubuntu notes below
   for installing graphviz.
 
-The following installation instructions are directed at developers working on
-Linux and MacOS operating systems. We assume familiarity with the following:
+## Step-by-step instructions
 
-- The command line/terminal
-- Unix commands such as `cd`.
-- Environment variables.
+1. Download and set up the Delphi database
+   ```
+   curl -O https://vision.cs.arizona.edu/adarsh/delphi.db
+   ```
 
-Here are the steps for installation.
+   Then, point the environment variable `DELPHI_DB` to point to `delphi.db`. On
+   Linux, you can do the following:
 
-- Fire up a terminal, navigate to the directory that you would like to
-  install Delphi in, then execute the following in the terminal:
+   ```
+   echo "export DELPHI_DB=`pwd`/delphi.db" >> ~/.bashrc
+   source ~/.bashrc
+   ```
 
-    ```bash 
+   If on a Mac, replace `~/.bashrc` with `~/.bash_profile`.
+
+2. Install Delphi using pip:
+  - If you are an _end-user_:
+    ```
+    pip install https://github.com/ml4ai/delphi/archive/master.zip
+    ```
+  - If you are a Delphi _developer_, create a fresh Python virtual environment,
+    activate it, and then run the following commands:
+    ```
     git clone https://github.com/ml4ai/delphi
-    cd delphi 
-    pip install .
-    ``` 
-
-
+    cd delphi
+    pip install -e .[test,docs]
+    ```
+  - To test if everything is set up properly, run the tests:
+    ```
+    make test
+    ```
 
 ### Graphviz installation notes
 
 #### MacOS
 
-This can be done using [Homebrew](https://brew.sh): 
+If you use the [Homebrew](https://brew.sh) package manager:
 
 ```bash
 brew install graphviz
@@ -61,71 +62,19 @@ pip install --install-option="--include-path=/usr/local/include/" \
             --install-option="--library-path=/usr/local/lib" pygraphviz
 ```
 
+If you use MacPorts, invoke the following command to install pygraphviz along
+with graphviz:
+
+```
+port install pygraphviz
+```
+
 ### Debian
 
 To install graphviz on Debian systems (like Ubuntu), do
 
 ```bash
 sudo apt-get install graphviz libgraphviz-dev pkg-config
-```
-
-### Environment variables
-
-There are several environment variables that need to be set in order
-for Delphi to function.
-
-#### Adding the Delphi root to the PYTHONPATH
-
-Set the PYTHONPATH to include the absolute path to the root of the
-delphi project. This can be set in one of two places:
-- In your `~/.bash_profile` (Mac) or `~/.bashrc` (linux) file. For example:
-    ```bash
-    export PYTHONPATH="/Users/claytonm/Documents/repository/delphi:$PYTHONPATH"
-    ```
-- If you use a virtual environment, instead of adding yet another
-    path to your global PYTHONPATH in your `~/.bash_profile` or `~/.bashrc`,
-    instead you can add the path to the Delphi root to be used only in your
-    virtual environment `project.pth` file. 
-    This has the advantage of not polluting your global PYTHONPATH when you
-    run python in other contexts (e.g., other virtual environments).
-    This file is located within the virtual 
-    environment as follows (the following assumes your virtual environment 
-    is named `<venv>`, and `<version>` is the version number of your python, 
-    such as 3.6 or 3.7):
-    ```
-    <venv>/lib/python<version>/site-packages/project.pth
-    ```
-    NOTE: you may need to create the `project.pth` if one does not already
-    exist.
-    To this file you simply add the absolute path to the Delphi root (you
-    do not use export or `PYTHONPATH`), for example:
-    ```
-    /Users/claytonm/Documents/repository/delphi
-    ```
-
-#### Other environment variables
-
-- To parameterize Delphi models correctly, you will need to set the
-    `DELPHI_DB` environment variable to the path to your local copy of the
-    Delphi SQLite database, which you can download with:
-
-    ```bash
-    curl http://vision.cs.arizona.edu/adarsh/delphi.db -o delphi.db
-    ```
-
-    Then set the variable enviornment (again, may be done within your bash
-    resource file or the virtual environment `project.pth`). 
-    The delphi.db name must appear at the end of the path, for example:
-
-    ```bash
-    export DELPHI_DB="/Users/claytonm/Documents/repository/delphi_db/delphi.db"
-    ```
-
-If you are developing Delphi and want to run tests or compile the
-documentation, then also do the following (from the root of Delphi): 
-
-```
-pip install -e .[test,docs]
 ```
 
 ### Building documentation
@@ -135,8 +84,13 @@ To build and view the documentation, run the following commands from the root of
 the repository:
 
 ```
-make docs; open docs/_build/html/index.html
+make docs
+```
+
+Then do the following (on MacOS) to open the docs webpage in a browser.
+
+```
+open docs/_build/html/index.html
 ```
 
 (On a Linux system, replace `open` with `xdg-open`)
-

--- a/docs/make_for2py_figures.py
+++ b/docs/make_for2py_figures.py
@@ -1,7 +1,6 @@
 from delphi import GroundedFunctionNetwork
 
-with open("relativistic_energy.f", "w") as f:
-    f.write("""\
+G = GroundedFunctionNetwork.from_fortran_src("""\
       subroutine relativistic_energy(e, m, c, p)
 
       implicit none
@@ -10,8 +9,7 @@ with open("relativistic_energy.f", "w") as f:
       e = sqrt((p**2)*(c**2) + (m**2)*(c**4))
 
       return
-      end subroutine func""")
-
-G = GroundedFunctionNetwork.from_fortran_file("relativistic_energy.f")
+      end subroutine relativistic_energy"""
+)
 A = G.to_agraph()
 A.draw("relativistic_energy_grfn.png", prog="dot")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ here = path.abspath(path.dirname(__file__))
 setup(
     name="delphi",
     version="4.0.1",
-    description="A framework for assembling probabilistic models from text.",
+    description="A framework for assembling probabilistic models from text and software.",
     url="https://github.com/ml4ai/delphi",
     author="ML4AI",
     author_email="adarsh@email.arizona.edu",
@@ -58,7 +58,6 @@ setup(
             "pyshp",
             "xlrd",
             "pyjnius",
-            "plotly",
         ],
         "test": [
             "pytest>=3.6.0",


### PR DESCRIPTION
This PR updates the documentation with
- more streamlined installation instructions
- Testing instructions

It also introduces a `from_fortran_src` constructor for the `GroundedFunctionNetwork` that can construct a GrFN from a string containing Fortran source code.