### PR TITLE
Dockerizing CodeExplorer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# .dockerignore taken from https://stackoverflow.com/a/51429852
+
+# Ignore everything
+**
+
+# Allow files and directories
+!/setup.py
+!/delphi/**
+
+# Ignore unnecessary files inside allowed directories
+# This should go after the allowed directories
+**/*~
+**/*.log
+**/*.swp
+**/.DS_Store
+**/Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use an official Python runtime as a parent image
+from python:3.6
+run apt-get update; apt-get install -y openjdk-8-jre
+
+workdir app
+copy setup.py /app
+copy delphi /app/delphi
+run pip install -e .
+
+# Make port 80 available to the world outside this container
+expose 80
+
+# Run app.py when the container launches
+cmd ["codex"]

--- a/delphi/apps/CodeExplorer/app.py
+++ b/delphi/apps/CodeExplorer/app.py
@@ -193,7 +193,7 @@ def modelAnalysis():
 
 
 def main():
-    app.run()
+    app.run(host='0.0.0.0', port=80)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds code to enable Dockerization of the CodeExplorer webapp.

To dockerize, do:

```
docker build -t codex .
```

The app will then be accessible at `localhost:5000` in the browser.

The image size is quite large at the moment, will look into ways of reducing it later.