### PR TITLE
Preprocessor to lower

### DIFF
--- a/delphi/translators/for2py/format.py
+++ b/delphi/translators/for2py/format.py
@@ -369,20 +369,20 @@ class Format:
 #           and-reference-rules-for-list-directed-sequential-write-statements
 
 LIST_WRITE_DEFAULTS = {
-    "BYTE": "I5",
-    "LOGICAL(1)": "L2",
-    "LOGICAL(2)": "L2",
-    "LOGICAL(4)": "L2",
-    "LOGICAL(8)": "L2",
-    "INTEGER": "I12",
-    "INTEGER(1)": "I5",
-    "INTEGER(2)": "I7",
-    "INTEGER(4)": "I12",
-    "INTEGER(8)": "I22",
-    "REAL": "1PE14.5E2",
-    "REAL(4)": "1PG15.7E2",
-    "REAL(8)": "1PG24.15E3",
-    "REAL(16)": "1PG43.33E4",
+    "byte": "i5",
+    "logical(1)": "l2",
+    "logical(2)": "l2",
+    "logical(4)": "l2",
+    "logical(8)": "l2",
+    "integer": "i12",
+    "integer(1)": "i5",
+    "integer(2)": "i7",
+    "integer(4)": "i12",
+    "integer(8)": "i22",
+    "real": "1pe14.5e2",
+    "real(4)": "1pg15.7e2",
+    "real(8)": "1pg24.15e3",
+    "real(16)": "1pg43.33e4",
 }
 
 

--- a/delphi/translators/for2py/format.py
+++ b/delphi/translators/for2py/format.py
@@ -427,9 +427,9 @@ def list_data_type(type_list):
         if not match:
             reps = 1
             if item[0] in "FfEegG":
-                data_type.append("REAL")
+                data_type.append("real")
             elif item[0] in "Ii":
-                data_type.append("INTEGER")
+                data_type.append("integer")
         else:
             reps = match.group(1)
             fmt = match.group(2)
@@ -442,9 +442,9 @@ def list_data_type(type_list):
             for i in range(int(reps)):
                 for ft in fmt:
                     if ft[0] in "FfEegG":
-                        data_type.append("REAL")
+                        data_type.append("real")
                     elif ft[0] in "Ii":
-                        data_type.append("INTEGER")
+                        data_type.append("integer")
     return data_type
 
 

--- a/delphi/translators/for2py/preprocessor.py
+++ b/delphi/translators/for2py/preprocessor.py
@@ -3,8 +3,10 @@
 """
 This module implements functions to preprocess Fortran source files prior to
 parsing to fix up some constructs (such as continuation lines) that are
-problematic for the OpenFortranParser front end. It can also be run as a script,
-as seen below.
+problematic for the OpenFortranParser front end. Along the way it converts
+the input code into lower-case to simplify subsequent processing.
+
+This code can also be run as a script, as seen below.
 Example:
     To invoke this script, do: ::
         ./preprocessor.py <infile> <outfile>

--- a/delphi/translators/for2py/preprocessor.py
+++ b/delphi/translators/for2py/preprocessor.py
@@ -256,7 +256,13 @@ def extract_comments(
         comments[curr_fn]["foot"] = curr_comment
         comments["$file_foot"] = curr_comment
 
-    return (lines, comments)
+    # convert the code to lower-case to simplify subsequent processing
+    lowercased_lines = []
+    for line in lines:
+        if line[1] != None:
+            lowercased_lines.append((line[0], line[1].lower()))
+
+    return (lowercased_lines, comments)
 
 
 def init_comment_map(head_cmt, neck_cmt, foot_cmt, internal_cmt):
@@ -341,4 +347,4 @@ if __name__ == "__main__":
     with open(outfile, "w") as f:
         for _, line in lines:
             if line is not None:
-                f.write(line.lower())
+                f.write(line)

--- a/delphi/translators/for2py/preprocessor.py
+++ b/delphi/translators/for2py/preprocessor.py
@@ -339,4 +339,4 @@ if __name__ == "__main__":
     with open(outfile, "w") as f:
         for _, line in lines:
             if line is not None:
-                f.write(line)
+                f.write(line.lower())

--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -724,7 +724,7 @@ class PythonCodeGenerator(object):
         self.pyStrings.append("")
 
     def printOpen(self, node, printState: PrintState):
-        if node["args"][0].get("arg_name") == "UNIT":
+        if node["args"][0].get("arg_name") == "unit":
             file_handle = "file_" + str(node["args"][1]["value"])
         elif node["args"][0].get("tag") == "ref":
             file_handle = "file_" + str(

--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -305,7 +305,7 @@ class PythonCodeGenerator(object):
         """Processes calls to intrinsic functions and returns a string that is
            the corresponding Python code."""
 
-        intrinsic = node["name"].lower()
+        intrinsic = node["name"]
         assert intrinsic in syntax.F_INTRINSICS
 
         try:
@@ -351,12 +351,12 @@ class PythonCodeGenerator(object):
            references, and that proc_call() is therefore correctly called only
            on function calls."""
 
-        if node["name"].lower() == "index":
+        if node["name"] == "index":
             var = self.nameMapper[node["args"][0]["name"]]
             toFind = node["args"][1]["value"]
             return f"{var}[0].find({toFind})"
 
-        if node["name"].lower() in syntax.F_INTRINSICS:
+        if node["name"] in syntax.F_INTRINSICS:
             return self.proc_intrinsic(node)
 
         callee = self.nameMapper[f"{node['name']}"]
@@ -452,7 +452,7 @@ class PythonCodeGenerator(object):
         """Processes expressions involving operators and returns a string that
            is the corresponding Python code."""
         try:
-            op_str = OPERATOR_MAP[node["operator"].lower()]
+            op_str = OPERATOR_MAP[node["operator"]]
         except KeyError:
             raise For2PyError(f"unhndled operator {node['operator']}")
 
@@ -530,7 +530,7 @@ class PythonCodeGenerator(object):
 
     def printArg(self, node, printState: PrintState):
         try:
-            var_type = TYPE_MAP[node["type"].lower()]
+            var_type = TYPE_MAP[node["type"]]
         except KeyError:
             raise For2PyError(f"unrecognized type {node['type']}")
 
@@ -686,12 +686,12 @@ class PythonCodeGenerator(object):
     def printUse(self, node, printState: PrintState):
         if node.get("include"):
             self.imports.append(
-                f"from delphi.translators.for2py.m_{node['arg'].lower()} "
+                f"from delphi.translators.for2py.m_{node['arg']} "
                 f"import {', '.join(node['include'])}\n"
             )
         else:
             self.imports.append(
-                f"from delphi.translators.for2py.m_{node['arg'].lower()} import *\n"
+                f"from delphi.translators.for2py.m_{node['arg']} import *\n"
             )
 
     def printFuncReturn(self, node, printState: PrintState):
@@ -1107,7 +1107,7 @@ class PythonCodeGenerator(object):
         """ This function checks the type of a variable and returns the appropriate
         Python syntax type name. """
 
-        variable_type = node["type"].lower()
+        variable_type = node["type"]
         if variable_type in TYPE_MAP:
             return TYPE_MAP[variable_type]
         else:
@@ -1308,8 +1308,8 @@ if __name__ == "__main__":
     outputList = []
     for item in python_source_list:
         if item[2] == "module":
-            with open(f"m_{item[1].lower()}.py", "w") as f:
-                outputList.append("m_" + item[1].lower() + ".py")
+            with open(f"m_{item[1]}.py", "w") as f:
+                outputList.append("m_" + item[1] + ".py")
                 f.write(item[0])
         else:
             with open(args.gen[0], "w") as f:

--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -184,7 +184,7 @@ class PythonCodeGenerator(object):
         self.funcArgs = {}
         self.getframe_expr = "sys._getframe({}).f_code.co_name"
         self.pyStrings = []
-        self.stateMap = {"UNKNOWN": "r", "REPLACE": "w"}
+        self.stateMap = {"unknown": "r", "replace": "w"}
         self.format_dict = {}
         self.declaredDerivedTVars = []
         self.declaredDerivedTypes = []
@@ -929,7 +929,7 @@ class PythonCodeGenerator(object):
         self.pyStrings.append(printState.sep)
         self.nameMapper[f"format_{node['label']}"] = f"format_{node['label']}"
         self.printVariable(
-            {"name": "format_" + node["label"], "type": "STRING"}, printState
+            {"name": "format_" + node["label"], "type": "string"}, printState
         )
         self.format_dict[node["label"]] = type_list
         self.pyStrings.extend(

--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -735,10 +735,10 @@ class PythonCodeGenerator(object):
         self.pyStrings.append(f"{file_handle} = ")
         for index, item in enumerate(node["args"]):
             if item.get("arg_name"):
-                if item["arg_name"] == "FILE":
+                if item["arg_name"] == "file":
                     file_name = node["args"][index + 1]["value"]
                     open_state = "r"
-                elif item["arg_name"] == "STATUS":
+                elif item["arg_name"] == "status":
                     open_state = node["args"][index + 1]["value"]
                     open_state = self.stateMap[open_state]
 

--- a/delphi/translators/for2py/translate.py
+++ b/delphi/translators/for2py/translate.py
@@ -293,7 +293,7 @@ class XMLToJSONTranslator(object):
         else:  # Else, this represents an empty element, which is the case of (1).
             declared_type = {
                 "type": root.attrib["name"],
-                "is_derived_type": root.attrib["is_derived_type"]
+                "is_derived_type": root.attrib["is_derived_type"],
                 "keyword2": root.attrib["keyword2"],
             }
             return [declared_type]
@@ -572,7 +572,7 @@ class XMLToJSONTranslator(object):
 
             ref = {
                 "tag": "ref",
-                "name": root.attrib["id"]
+                "name": root.attrib["id"],
                 "numPartRef": str(numPartRef),
                 "hasSubscripts": root.attrib["hasSubscripts"],
                 "is_array": is_array,

--- a/delphi/translators/for2py/translate.py
+++ b/delphi/translators/for2py/translate.py
@@ -154,7 +154,7 @@ class XMLToJSONTranslator(object):
 
     def process_subroutine_or_program_module(self, root, state):
         """ This function should be the very first function to be called """
-        subroutine = {"tag": root.tag, "name": root.attrib["name"].lower()}
+        subroutine = {"tag": root.tag, "name": root.attrib["name"]}
         self.summaries[root.attrib["name"]] = None
         if root.tag == "subroutine":
             self.subroutineList.append(root.attrib["name"])
@@ -179,7 +179,7 @@ class XMLToJSONTranslator(object):
         call = {"tag": "call"}
         for node in root:
             if node.tag == "name":
-                call["name"] = node.attrib["id"].lower()
+                call["name"] = node.attrib["id"]
                 call["args"] = []
                 for arg in node:
                     call["args"] += self.parseTree(arg, state)
@@ -190,7 +190,7 @@ class XMLToJSONTranslator(object):
         list and copy the values (tag and attributes) to it.  """
 
         assert root.tag == "argument", "The root must be <argument>"
-        return [{"tag": "arg", "name": root.attrib["name"].lower()}]
+        return [{"tag": "arg", "name": root.attrib["name"]}]
 
     def process_declaration(self, root, state) -> List[Dict]:
         """ This function handles <declaration> tag and its sub-elements by
@@ -276,9 +276,7 @@ class XMLToJSONTranslator(object):
                 elif node.tag == "length":
                     is_derived_type = False
                     if "is_derived_type" in root.attrib:
-                        is_derived_type = root.attrib[
-                            "is_derived_type"
-                        ].lower()
+                        is_derived_type = root.attrib["is_derived_type"]
                     keyword2 = "none"
                     if "keyword2" in root.attrib:
                         keyword2 = root.attrib["keyword2"]
@@ -295,7 +293,7 @@ class XMLToJSONTranslator(object):
         else:  # Else, this represents an empty element, which is the case of (1).
             declared_type = {
                 "type": root.attrib["name"],
-                "is_derived_type": root.attrib["is_derived_type"].lower(),
+                "is_derived_type": root.attrib["is_derived_type"]
                 "keyword2": root.attrib["keyword2"],
             }
             return [declared_type]
@@ -338,8 +336,8 @@ class XMLToJSONTranslator(object):
             root.tag == "variable"
         ), f"The root must be <variable>. Current tag is {root.tag} with {root.attrib} attributes."
         try:
-            var_name = root.attrib["name"].lower()
-            is_array = root.attrib["is_array"].lower()
+            var_name = root.attrib["name"]
+            is_array = root.attrib["is_array"]
 
             variable = {"name": var_name, "is_array": is_array}
             if is_array == "true":
@@ -432,7 +430,7 @@ class XMLToJSONTranslator(object):
         assert (
             root.tag == "index-variable"
         ), f"The root must be <index-variable>. Current tag is {root.tag} with {root.attrib} attributes."
-        ind = {"tag": "index", "name": root.attrib["name"].lower()}
+        ind = {"tag": "index", "name": root.attrib["name"]}
         for bounds in root:
             if bounds.tag == "lower-bound":
                 ind["low"] = self.parseTree(bounds, state)
@@ -548,7 +546,7 @@ class XMLToJSONTranslator(object):
         assert (
             root.tag == "name"
         ), f"The root must be <name>. Current tag is {root.tag} with {root.attrib} attributes."
-        if root.attrib["id"].lower() in self.libFns:
+        if root.attrib["id"] in self.libFns:
             fn = {"tag": "call", "name": root.attrib["id"], "args": []}
             for node in root:
                 fn["args"] += self.parseTree(node, state)
@@ -557,7 +555,7 @@ class XMLToJSONTranslator(object):
             root.attrib["id"] in self.functionList
             and state.subroutine["tag"] != "function"
         ):
-            fn = {"tag": "call", "name": root.attrib["id"].lower(), "args": []}
+            fn = {"tag": "call", "name": root.attrib["id"], "args": []}
             for node in root:
                 fn["args"] += self.parseTree(node, state)
             return [fn]
@@ -574,7 +572,7 @@ class XMLToJSONTranslator(object):
 
             ref = {
                 "tag": "ref",
-                "name": root.attrib["id"].lower(),
+                "name": root.attrib["id"]
                 "numPartRef": str(numPartRef),
                 "hasSubscripts": root.attrib["hasSubscripts"],
                 "is_array": is_array,
@@ -618,10 +616,9 @@ class XMLToJSONTranslator(object):
                 assign["value"] = self.parseTree(node, state)
 
         if (
-            assign["target"][0]["name"]
-            in [x.lower() for x in self.functionList]
+            assign["target"][0]["name"] in [x for x in self.functionList]
         ) and (
-            assign["target"][0]["name"] == state.subroutine["name"].lower()
+            assign["target"][0]["name"] == state.subroutine["name"]
         ):
             assign["value"][0]["tag"] = "ret"
             return assign["value"]
@@ -633,7 +630,7 @@ class XMLToJSONTranslator(object):
         assert (
             root.tag == "function"
         ), f"The root must be <function>. Current tag is {root.tag} with {root.attrib} attributes."
-        subroutine = {"tag": root.tag, "name": root.attrib["name"].lower()}
+        subroutine = {"tag": root.tag, "name": root.attrib["name"]}
         self.summaries[root.attrib["name"]] = None
         for node in root:
             if node.tag == "header":
@@ -757,7 +754,7 @@ class XMLToJSONTranslator(object):
         """
         for node in root:
             if node.tag == "name":
-                return [{"tag": "private", "name": node.attrib["id"].lower()}]
+                return [{"tag": "private", "name": node.attrib["id"]}]
 
         return []
 


### PR DESCRIPTION
This PR has the preprocessor convert the Fortran source code into lower-case before writing it out.  This frees us from having to constantly convert to lower-case in translate.py and pyTranslate.py.