### PR TITLE
Issue 249

### DIFF
--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -171,25 +171,40 @@ class PrintState:
 
 class PythonCodeGenerator(object):
     def __init__(self):
+        # Variable to hold the program name
         self.programName = ""
+        # Dictionary to hold the tag mapping to the
+        # print function that needs to be invoked
         self.printFn = {}
+        # Dictionary to hold the declared variable
+        # and its declared type
         self.variableMap = {}
+        # List to hold the imports in the program
         self.imports = []
-        # This list contains the private functions
+        # List to hold the private functions
         self.privFunctions = []
-        # This dictionary contains the mapping of symbol names to pythonic
-        # names
+        # Dictionary to hold declared symbols (variable,
+        # function, and format, etc) as key and map to
+        # the symbol name that will be used in the python IR output
         self.nameMapper = {}
-        # Dictionary to hold functions and its arguments
+        # List to hold the declared function names
         self.functions = []
+        # Dictionary to hold functions and its arguments
         self.funcArgs = {}
+        # Pre-defined string format of system getframe
         self.getframe_expr = "sys._getframe({}).f_code.co_name"
+        # List to hold the translated python string that
+        # will be printed to the python IR output
         self.pyStrings = []
+        # Dictionary holding mapping of read/write 
+        # based on the file open state
         self.stateMap = {"UNKNOWN": "r", "REPLACE": "w"}
+        # Dictionary to hold the mapping of {label:format-code}
         self.format_dict = {}
-        # List to hold derived type class and variables
-        self.declaredDerivedTVars = []
+        # Lists to hold derived type class
         self.declaredDerivedTypes = []
+        # Lists to hold derived type variables
+        self.declaredDerivedTVars = []
 
         self.printFn = {
             "subroutine": self.printSubroutine,
@@ -715,13 +730,11 @@ class PythonCodeGenerator(object):
                         "right" in node
                     ), f"Something is missing. Detail of node content: {node}"
 
-                    left = ""
                     if node["left"][0]["tag"] == "ref":
                         left = node["left"][0]["name"]
                     else:
                         left = node["left"][0]["value"]
                     operator = node["operator"]
-                    right = ""
                     if node["right"][0]["tag"] == "ref":
                         right = node["right"][0]["name"]
                     else:

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -56,7 +56,14 @@ class RectifyOFPXML:
     """
         Nested child tag list
     """
-    file_child_tags = ["program", "subroutine", "module"]
+    file_child_tags = [
+        "program", 
+        "subroutine", 
+        "module", 
+        "declaration", 
+        "function", 
+        "prefix"
+    ]
 
     statement_child_tags = [
         "assignment",
@@ -1267,6 +1274,8 @@ class RectifyOFPXML:
                 ...
             </function>
         """
+        # REMOVE
+        print ("tag_function: ", root.tag, root.attrib)
         self.current_scope = root.attrib["name"]
         for child in root:
             self.clean_attrib(child)

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -1274,8 +1274,6 @@ class RectifyOFPXML:
                 ...
             </function>
         """
-        # REMOVE
-        print ("tag_function: ", root.tag, root.attrib)
         self.current_scope = root.attrib["name"]
         for child in root:
             self.clean_attrib(child)


### PR DESCRIPTION
Handled the issue of function AST does not get printed by rectify.py.
Handled the issue of pyTranslate.py does not print the function properly.
Tested with the given example.

`    integer function foo(x)
      implicit none
      integer x
      foo = x + 1234567      ! return value of the function
      end function foo

      program main
      integer u, foo
      u = foo(3)
 10   format(I8)
      write (*,10) u
      end program main`