### PR TITLE
Removing imports in delphi/__init__.py to keep code more modular

### DIFF
--- a/delphi/__init__.py
+++ b/delphi/__init__.py
@@ -1,2 +1,0 @@
-from .AnalysisGraph import AnalysisGraph
-# from .GrFN.networks import GroundedFunctionNetwork

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Usage
 
 .. code-block:: python
 
-  from delphi import AnalysisGraph
+  from delphi.AnalysisGraph import AnalysisGraph
 
   G = AnalysisGraph.from_text(
       "Significantly increased conflict seen in South Sudan forced many"
@@ -46,7 +46,7 @@ Usage
 
 .. code-block:: python
 
-  from delphi import GroundedFunctionNetwork
+  from delphi.GrFN.networks import GroundedFunctionNetwork
 
   G = GroundedFunctionNetwork.from_fortran_src("""\
         subroutine relativistic_energy(e, m, c, p)

--- a/docs/make_figures.py
+++ b/docs/make_figures.py
@@ -1,4 +1,4 @@
-from delphi import AnalysisGraph
+from delphi.AnalysisGraph import AnalysisGraph
 
 G = AnalysisGraph.from_text(
     "Significantly increased conflict seen in "

--- a/docs/make_for2py_figures.py
+++ b/docs/make_for2py_figures.py
@@ -1,4 +1,4 @@
-from delphi import GroundedFunctionNetwork
+from delphi.GrFN.networks import GroundedFunctionNetwork
 
 G = GroundedFunctionNetwork.from_fortran_src("""\
       subroutine relativistic_energy(e, m, c, p)


### PR DESCRIPTION
This PR removes some imports in Delphi/__init__.py to keep code more modular and enable easier development of separate parts of Delphi (and also to make the creation of singularity containers easier).