### PR TITLE
Derived type test

### DIFF
--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -40,11 +40,6 @@ NEGATED_OP = {
                 ">=" : "<"
               }
 
-# Const variable for setting
-# a maximum range for random
-# number generation
-RANGE = 9999
-
 class RectifyOFPXML:
     def __init__(self):
         # True if derived type declaration exist

--- a/tests/test_program_analysis.py
+++ b/tests/test_program_analysis.py
@@ -102,6 +102,10 @@ def do_while_python_IR_test():
     yield get_python_source(Path(f"{DATA_DIR}/do-while/do_while_04.f"))[0]
 
 @pytest.fixture
+def derived_type_python_IR_test():
+    yield get_python_source(Path(f"{DATA_DIR}/derived-types/derived-types-04.f"))[0]
+
+@pytest.fixture
 def goto_python_IR_test():
     yield get_python_source(Path(f"{DATA_DIR}/goto/goto_02.f"))[0]
 
@@ -129,6 +133,11 @@ def test_do_while_pythonIR_generation(do_while_python_IR_test):
     with open(f"{DATA_DIR}/do-while/do_while_04.py", "r") as f:
         python_src = f.read()
     assert do_while_python_IR_test == python_src
+
+def test_derived_type_pythonIR_generation(derived_type_python_IR_test):
+    with open(f"{DATA_DIR}/derived-types-04.py", "r") as f:
+        python_src = f.read()
+    assert derived_type_python_IR_test == python_src
 
 def test_goto_pythonIR_generation(goto_python_IR_test):
     with open(f"{DATA_DIR}/goto/goto_02.py", "r") as f:


### PR DESCRIPTION
This PR holds:
(1) A test for the derived type.
(2) Removed unnecessary global variable in the rectify.py.