### PR TITLE
Fix a minor bug in handling FORMAT stmts

### DIFF
--- a/delphi/translators/for2py/format.py
+++ b/delphi/translators/for2py/format.py
@@ -242,7 +242,7 @@ class Format:
                 idx0 = fmt.find(".")
                 sz = fmt[1:idx0]
                 divisor = 10 ** (int(fmt[idx0 + 1 :]))
-                xtract_rexp = "(.{" + sz + "})"  # r.e. for extraction
+                xtract_rexp = "(.{," + sz + "})"  # r.e. for extraction
                 leading_sp = " *"
                 optional_sign = "-?"
                 rexp0 = "\d+(\.\d+)?"


### PR DESCRIPTION
The existing code for handling FORMAT statements requires that input strings match the width of the format specifier exactly.  In practice, Fortran allows the input string to be shorter than the format specifier (the difference gets zero-padded).  This bug fix addresses this problem.