### PR TITLE
Added a fix for unhandled case of operation under write. Then a minor…

### DIFF
--- a/delphi/translators/for2py/f2grfn.py
+++ b/delphi/translators/for2py/f2grfn.py
@@ -230,7 +230,7 @@ def generate_python_src(outputDict, python_file, output_file, tester_call):
 
 
 def generate_grfn(
-    python_src, python_file, lambdas_file, json_file, mode_mapper_dict
+    python_src, python_file, lambdas_file, json_file, mode_mapper_dict, tester_call
 ):
     """
         This function generates GrFN dictionary object and file.
@@ -479,7 +479,7 @@ def fortran_to_grfn(
             mode_mapper_dict,
         )
     else:
-        return (python_src, lambdas_file, json_file, base)
+        return (python_src, lambdas_file, json_file, base, tester_call)
 
 
 if __name__ == "__main__":
@@ -493,5 +493,5 @@ if __name__ == "__main__":
 
     # Generate GrFN file
     grfn_dict = generate_grfn(
-        python_src, python_file, lambdas_file, json_file, mode_mapper_dict
+        python_src, python_file, lambdas_file, json_file, mode_mapper_dict, False
     )

--- a/delphi/translators/for2py/f2grfn.py
+++ b/delphi/translators/for2py/f2grfn.py
@@ -479,7 +479,7 @@ def fortran_to_grfn(
             mode_mapper_dict,
         )
     else:
-        return (python_src, lambdas_file, json_file, base, tester_call)
+        return (python_src, lambdas_file, json_file, base)
 
 
 if __name__ == "__main__":

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -1752,7 +1752,7 @@ class RectifyOFPXML:
             cur_elem = ET.SubElement(
                 current, child.tag, child.attrib
             )
-            if child.tag == "name" or child.tag == "literal":
+            if child.tag == "name" or child.tag == "literal" or child.tag == "operation":
                 self.parseXMLTree(
                     child, cur_elem, current, parent, traverse
                 )

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -356,6 +356,12 @@ class RectifyOFPXML:
         "saved-entity-list",
     ]
 
+    output_child_tags = [
+        "name",
+        "literal",
+        "operation",
+    ]
+
     #################################################################
     #                                                               #
     #                       HANDLER FUNCTONS                        #
@@ -1752,7 +1758,7 @@ class RectifyOFPXML:
             cur_elem = ET.SubElement(
                 current, child.tag, child.attrib
             )
-            if child.tag == "name" or child.tag == "literal" or child.tag == "operation":
+            if child.tag in self.output_child_tags:
                 self.parseXMLTree(
                     child, cur_elem, current, parent, traverse
                 )

--- a/tests/aske/test_program_analysis.py
+++ b/tests/aske/test_program_analysis.py
@@ -31,6 +31,7 @@ def make_grfn_dict(original_fortran_file) -> Dict:
         lambdas_filename,
         json_filename,
         mode_mapper_dict,
+        True
     )
 
     return _dict


### PR DESCRIPTION
This PR includes a fix in the rectify.py for an unhandled case of where an operation was given as an argument for the write function in Fortran. Also, a minor fix for f2grfn where tester_call = True/False argument is missing in the generate_grfn function.