### PR TITLE
Fixed python src. passing and grfn generation handler

### DIFF
--- a/delphi/translators/for2py/f2grfn.py
+++ b/delphi/translators/for2py/f2grfn.py
@@ -518,7 +518,7 @@ def fortran_to_grfn(
 
     if not network_test:
         return (
-            [src[0] for src in python_src],
+            python_src,
             lambdas_file,
             json_file,
             python_file,
@@ -542,5 +542,5 @@ if __name__ == "__main__":
 
     # Generate GrFN file
     grfn_dict = generate_grfn(
-        python_src, python_file, lambdas_file, json_file, mode_mapper_dict, False
+        python_src[0][0], python_file, lambdas_file, json_file, mode_mapper_dict, False
     )

--- a/tests/aske/test_program_analysis.py
+++ b/tests/aske/test_program_analysis.py
@@ -26,7 +26,7 @@ def make_grfn_dict(original_fortran_file) -> Dict:
         original_fortran_file
     )
     _dict = f2grfn.generate_grfn(
-        pySrc,
+        pySrc[0][0],
         python_filename,
         lambdas_filename,
         json_filename,
@@ -79,8 +79,7 @@ def do_while_python_IR_test():
 @pytest.fixture
 def derived_type_python_IR_test():
     yield get_python_source(
-        Path(f"{DATA_DIR}/derived-types/derived-types-04.f")
-    )[0][0]
+        Path(f"{DATA_DIR}/derived-types/derived-types-04.f"))[0][0]
 
 
 @pytest.fixture
@@ -112,7 +111,7 @@ def cycle_exit_python_IR_test():
 @pytest.fixture
 def module_python_IR_test():
     yield get_python_source(
-        Path(f"{DATA_DIR}" f"/modules/test_module_08.f"))[0]
+        Path(f"{DATA_DIR}" f"/modules/test_module_08.f"))
 
 
 @pytest.fixture
@@ -137,84 +136,84 @@ def continuation_lines_f90_python_IR_test():
 def test_crop_yield_pythonIR_generation(crop_yield_python_IR_test):
     with open(f"{DATA_DIR}/crop_yield.py", "r") as f:
         python_src = f.read()
-    assert crop_yield_python_IR_test == python_src
+    assert crop_yield_python_IR_test[0] == python_src
 
 
 def test_PETPT_pythonIR_generation(PETPT_python_IR_test):
     with open(f"{DATA_DIR}/PETPT.py", "r") as f:
         python_src = f.read()
-    assert PETPT_python_IR_test == python_src
+    assert PETPT_python_IR_test[0] == python_src
 
 
 def test_io_test_pythonIR_generation(io_python_IR_test):
     with open(f"{DATA_DIR}/io-tests/iotest_05.py", "r") as f:
         python_src = f.read()
-    assert io_python_IR_test == python_src
+    assert io_python_IR_test[0] == python_src
 
 
 def test_array_pythonIR_generation(array_python_IR_test):
     with open(f"{DATA_DIR}/arrays-basic-06.py", "r") as f:
         python_src = f.read()
-    assert array_python_IR_test == python_src
+    assert array_python_IR_test[0] == python_src
 
 
 def test_do_while_pythonIR_generation(do_while_python_IR_test):
     with open(f"{DATA_DIR}/do-while/do_while_04.py", "r") as f:
         python_src = f.read()
-    assert do_while_python_IR_test == python_src
+    assert do_while_python_IR_test[0] == python_src
 
 
 def test_derived_type_pythonIR_generation(derived_type_python_IR_test):
     with open(f"{DATA_DIR}/derived-types-04.py", "r") as f:
         python_src = f.read()
-    assert derived_type_python_IR_test == python_src
+    assert derived_type_python_IR_test[0] == python_src
 
 
 def test_conditional_goto_pythonIR_generation(cond_goto_python_IR_test):
     with open(f"{DATA_DIR}/goto/goto_02.py", "r") as f:
         python_src = f.read()
-    assert cond_goto_python_IR_test == python_src
+    assert cond_goto_python_IR_test[0] == python_src
 
 
 def test_unconditional_goto_pythonIR_generation(uncond_goto_python_IR_test):
     with open(f"{DATA_DIR}/goto/goto_08.py", "r") as f:
         python_src = f.read()
-    assert uncond_goto_python_IR_test == python_src
+    assert uncond_goto_python_IR_test[0] == python_src
 
 
 def test_unconditional_goto_pythonIR_generation(diff_level_goto_python_IR_test):
     with open(f"{DATA_DIR}/goto/goto_09.py", "r") as f:
         python_src = f.read()
-    assert diff_level_goto_python_IR_test == python_src
+    assert diff_level_goto_python_IR_test[0] == python_src
 
 
 def test_save_pythonIR_generation(save_python_IR_test):
     with open(f"{DATA_DIR}/save/simple_variables/save-02.py", "r") as f:
         python_src = f.read()
-    assert save_python_IR_test == python_src
+    assert save_python_IR_test[0] == python_src
 
 
 def test_module_pythonIR_generation(module_python_IR_test):
-    src = module_python_IR_test
+    src = module_python_IR_test[0]
     with open(f"{DATA_DIR}/modules/test_module_08.py", "r") as f:
         python_src = f.read()
-    assert src[1] == python_src
+    assert src[1][0] == python_src
 
     with open(f"{DATA_DIR}/modules/m_mymod8.py", "r") as f:
         python_src = f.read()
-    assert src[0] == python_src
+    assert src[0][0] == python_src
 
 
 def test_cycle_exit_pythonIR_generation(cycle_exit_python_IR_test):
     with open(f"{DATA_DIR}/cycle/cycle_03.py", "r") as f:
         python_src = f.read()
-    assert cycle_exit_python_IR_test == python_src
+    assert cycle_exit_python_IR_test[0] == python_src
 
 
 def test_continue_line_pythonIR_generation(continuation_lines_python_IR_test):
     with open(f"{DATA_DIR}/continuation_line/continuation-lines-01.py", "r") as f:
         python_src = f.read()
-    assert continuation_lines_python_IR_test == python_src
+    assert continuation_lines_python_IR_test[0] == python_src
 
 
 def test_continue_line_f90_pythonIR_generation(
@@ -222,4 +221,4 @@ def test_continue_line_f90_pythonIR_generation(
 ):
     with open(f"{DATA_DIR}/continuation_line/continuation-lines-02.py", "r") as f:
         python_src = f.read()
-    assert continuation_lines_f90_python_IR_test == python_src
+    assert continuation_lines_f90_python_IR_test[0] == python_src


### PR DESCRIPTION
This PR holds a fix for how generated python source gets returned
and passed to the GrFN generation function argument. This change required
modification in the `test_program_analysis.py` on how tests handle
the received python source object.