### PR TITLE
Cpp delete indicator

### DIFF
--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -1770,6 +1770,30 @@ class AnalysisGraph {
     }
   }
 
+  void delete_indicator(string concept, string indicator) {
+    try {
+      this->graph[this->name_to_vertex.at(concept)].delete_indicator(indicator);
+      this->indicators_in_CAG.erase(indicator);
+    }
+    catch (const out_of_range &oor) {
+      cerr << "Error: AnalysisGraph::delete_indicator()\n"
+           << "\tConcept: " << concept << " is not in the CAG\n";
+      cerr << "\tIndicator: " << indicator << " cannot be deleted" << endl;
+    }
+  
+  }
+
+  void delete_all_indicators(string concept) {
+    try {
+      this->graph[this->name_to_vertex.at(concept)].clear_indicators();
+    }
+    catch (const out_of_range &oor) {
+      cerr << "Error: AnalysisGraph::delete_indicator()\n"
+           << "\tConcept: " << concept << " is not in the CAG\n";
+      cerr << "\tIndicators cannot be deleted" << endl;
+    }
+    
+  }
   /*
   // TODO: Demosntrate how to use the Node::get_indicator() method
   // with the custom exception.

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -79,6 +79,23 @@ struct Node {
     indicators.push_back(Indicator(indicator, source));
   }
 
+
+  void delete_indicator(std::string indicator) {
+    if (indicator_names.find(indicator) != indicator_names.end()) {
+      int ind_index = indicator_names[indicator];
+      indicator_names.clear();
+      indicators.erase(indicators.begin() + ind_index);
+      //The values of the map object have to align with the vecter indexes.
+      for (int i = 0; i < indicators.size(); i++) {
+        indicator_names[indicators[i].get_name()] = i;
+      }
+    }
+    else {
+      std::cout << "There is no indicator  " << indicator << "attached to " << name << std::endl;  
+    }
+  }
+
+
   Indicator get_indicator(std::string indicator) {
     try {
       return indicators[indicator_names.at(indicator)];
@@ -87,6 +104,7 @@ struct Node {
       throw IndicatorNotFoundException(indicator);
     }
   }
+  
 
   void replace_indicator(std::string indicator_old,
                          std::string indicator_new,

--- a/lib/AnalysisGraph_wrapper.cpp
+++ b/lib/AnalysisGraph_wrapper.cpp
@@ -48,6 +48,9 @@ PYBIND11_MODULE(AnalysisGraph, m) {
            "indicator"_a, "source"_a)
       .def("replace_indicator", &AnalysisGraph::replace_indicator, "concept"_a,
            "indicator_old"_a, "indicator_new"_a, "source"_a)
+      .def("delete_indicator", &AnalysisGraph::delete_indicator, "concept"_a, 
+          "indicator"_a)
+      .def("delete_all_indicators", &AnalysisGraph::delete_all_indicators, "concept"_a)
       //.def("get_indicator", &AnalysisGraph::get_indicator, "concept"_a,
       //     "indicator"_a, py::return_value_policy::automatic)
       .def("test_inference_with_synthetic_data",

--- a/tests/wm/test_cpp_evaluation.py
+++ b/tests/wm/test_cpp_evaluation.py
@@ -26,6 +26,7 @@ def test_cpp_extensions():
         "UNHCR",
     )
     G.print_indicators()
+
     # Now we can specify how to initialize betas. Posible values are:
     # InitialBeta.ZERO
     # InitialBeta.ONE
@@ -41,3 +42,40 @@ def test_cpp_extensions():
     predicted_point = preds[1][0]
     for ts in predicted_point:
         print(ts)
+    print("\n")
+
+def test_delete_indicator():
+    statements = [
+        (
+            ("large", -1, "UN/entities/human/financial/economic/inflation"),
+            ("small", 1, "UN/events/human/human_migration"),
+        )
+    ]
+    G = AnalysisGraph.from_causal_fragments(statements)
+    print("\n")
+    G.print_nodes()
+    G.map_concepts_to_indicators()
+    G.print_indicators()
+    print("\n")
+    G.replace_indicator(
+        "UN/events/human/human_migration",
+        "Net migration",
+        "New asylum seeking applicants",
+        "UNHCR",
+    )
+    G.print_indicators()
+    print("\n")
+    G.set_indicator("UN/events/human/human_migration", "Net Migration", "MITRE12")
+
+    G.print_indicators()
+    print("\n")
+    G.delete_indicator("UN/events/human/human_migration", "New asylum seeking applicants")
+
+    G.print_indicators()
+    print("\n")
+
+    G.set_indicator("UN/events/human/human_migration", "New asylum seeking applicants", "UNHCR")
+
+    G.delete_all_indicators("UN/events/human/human_migration")
+
+    G.print_indicators()


### PR DESCRIPTION
This adds delete_indicator to AnalysisGraph.cpp which deletes a single indicator from a concept as well as delete_all_indicators which deletes all indicators from a concept. 