### PR TITLE
Bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ test: extensions
 	  --ignore=delphi/translators/for2py/data\
 	  --ignore=tests/data\
 	  delphi tests
-	./build/cpptests
 
 pypi_upload:
 	rm -rf dist

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -41,9 +41,6 @@ class AnalysisGraph {
   // block This is ugly. We need to re-factor the code to make it pretty again
   auto vertices();
 
-  // This returns an iterator over Node objects in the graph.
-  auto nodes();
-
   NEIGHBOR_ITERATOR successors(int i);
 
   // Allocate a num_verts x num_verts 2D array (std::vector of std::vectors)

--- a/lib/DiGraph.hpp
+++ b/lib/DiGraph.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <string>
-#include "random_variables.hpp"
 #include "kde.hpp"
+#include "random_variables.hpp"
 #include <boost/graph/adjacency_list.hpp>
+#include <string>
 
 class IndicatorNotFoundException : public std::exception {
   public:
@@ -11,7 +11,7 @@ class IndicatorNotFoundException : public std::exception {
 
   IndicatorNotFoundException(std::string msg) : msg(msg) {}
 
-  const char *what() const throw() { return this->msg.c_str(); }
+  const char* what() const throw() { return this->msg.c_str(); }
 };
 
 class Node {
@@ -43,32 +43,30 @@ class Node {
     indicators.push_back(Indicator(indicator, source));
   }
 
-
   void delete_indicator(std::string indicator) {
     if (indicator_names.find(indicator) != indicator_names.end()) {
       int ind_index = indicator_names[indicator];
       indicator_names.clear();
       indicators.erase(indicators.begin() + ind_index);
-      //The values of the map object have to align with the vecter indexes.
+      // The values of the map object have to align with the vecter indexes.
       for (int i = 0; i < indicators.size(); i++) {
         indicator_names[indicators[i].get_name()] = i;
       }
     }
     else {
-      std::cout << "There is no indicator  " << indicator << "attached to " << name << std::endl;  
+      std::cout << "There is no indicator  " << indicator << "attached to "
+                << name << std::endl;
     }
   }
-
 
   Indicator get_indicator(std::string indicator) {
     try {
       return indicators[indicator_names.at(indicator)];
     }
-    catch (const std::out_of_range &oor) {
+    catch (const std::out_of_range& oor) {
       throw IndicatorNotFoundException(indicator);
     }
   }
-  
 
   void replace_indicator(std::string indicator_old,
                          std::string indicator_new,
@@ -121,15 +119,9 @@ class Statement {
   Event subject;
   Event object;
 
-  Statement() :
-    subject(Event("", 0, "" )),
-    object(Event("", 0, ""))
-    {}
+  Statement() : subject(Event("", 0, "")), object(Event("", 0, "")) {}
 
-  Statement(Event sub, Event obj) :
-    subject(sub),
-    object(obj)
-    {}
+  Statement(Event sub, Event obj) : subject(sub), object(obj) {}
 };
 
 class Edge {
@@ -168,5 +160,17 @@ typedef boost::adjacency_list<boost::setS,
                               GraphData>
     DiGraph;
 
-typedef boost::iterator_range<boost::adjacency_iterator<DiGraph, long unsigned int, boost::detail::out_edge_iter<std::_Rb_tree_const_iterator<boost::detail::stored_edge_iter<long unsigned int, std::_List_iterator<boost::list_edge<long unsigned int, Edge> >, Edge> >, long unsigned int, boost::detail::edge_desc_impl<boost::bidirectional_tag, long unsigned int>, long int>, long int> >
+typedef boost::iterator_range<boost::adjacency_iterator<
+    DiGraph,
+    long unsigned int,
+    boost::detail::out_edge_iter<
+        std::_Rb_tree_const_iterator<boost::detail::stored_edge_iter<
+            long unsigned int,
+            std::_List_iterator<boost::list_edge<long unsigned int, Edge>>,
+            Edge>>,
+        long unsigned int,
+        boost::detail::edge_desc_impl<boost::bidirectional_tag,
+                                      long unsigned int>,
+        long int>,
+    long int>>
     NEIGHBOR_ITERATOR;

--- a/tests/wm/conftest.py
+++ b/tests/wm/conftest.py
@@ -108,4 +108,6 @@ def G_eval():
 def G_unit():
     G = AnalysisGraph.from_statements([s3])
     G.map_concepts_to_indicators()
+    G.res = 200
+    G.sample_from_prior()
     yield G


### PR DESCRIPTION
This PR reverts the node iterator - there is some weird behavior that makes the concept to indicator mapping not work properly.

@manujinda @lchamp87x I'm also removing the invocation of ./build/cpptests from the Makefile test target since our Python and C++ tests tend to get out of sync, and it'll be easier just to maintain the downstream ones (i.e. Python).