### PR TITLE
Bugfixes and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,27 @@ include_directories(external/eigen)
 find_package(SQLite3 REQUIRED)
 include_directories(${SQLITE3_INCLUDE_DIRS})
 
-add_library(Delphi ${SRC_FILES})
+add_library(Delphi 
+  lib/AnalysisGraph.cpp
+  lib/AnalysisGraph.hpp
+  lib/construct_beta_pdfs.cpp
+  lib/data.cpp
+  lib/data.hpp
+  lib/DiGraph.hpp
+  lib/graphviz_interface.cpp
+  lib/graphviz_interface.hpp
+  lib/kde.cpp
+  lib/kde.hpp
+  lib/random_variables.cpp
+  lib/random_variables.hpp
+  lib/rng.cpp
+  lib/rng.hpp
+  lib/train_model.cpp
+  lib/tran_mat_cell.hpp
+  lib/utils.cpp
+  lib/utils.hpp
+)
+
 target_link_libraries(Delphi
                       PRIVATE ${Boost_LIBRARIES}
                               fmt::fmt

--- a/apps/create_model.cpp
+++ b/apps/create_model.cpp
@@ -8,9 +8,9 @@ using namespace std;
 int main(int argc, char* argv[]) {
   RNG *R = RNG::rng();
   R->set_seed(87);
-  spdlog::info("Test message");
   spdlog::set_level(spdlog::level::debug);
-  auto G = AnalysisGraph::from_json_file(argv[1], 0.9, 0.0);
+  auto G = AnalysisGraph::from_json_file(argv[1], 0.0, 0.0);
+  G.print_nodes();
   G = G.get_subgraph_for_concept("UN/events/human/human_migration", true, 2);
   G.map_concepts_to_indicators();
   G.replace_indicator("UN/events/human/human_migration",

--- a/apps/create_model.cpp
+++ b/apps/create_model.cpp
@@ -9,8 +9,7 @@ int main(int argc, char* argv[]) {
   RNG *R = RNG::rng();
   R->set_seed(87);
   spdlog::set_level(spdlog::level::debug);
-  auto G = AnalysisGraph::from_json_file(argv[1], 0.0, 0.0);
-  G.print_nodes();
+  auto G = AnalysisGraph::from_json_file(argv[1], 0.9, 0.0);
   G = G.get_subgraph_for_concept("UN/events/human/human_migration", true, 2);
   G.map_concepts_to_indicators();
   G.replace_indicator("UN/events/human/human_migration",

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -112,23 +112,21 @@ void AnalysisGraph::parameterize(string country,
                                  map<string, string> units) {
   double stdev;
   for (auto& node : this->nodes()) {
-    for (auto [name, i] : node.indicator_names) {
-      auto indicator = node.indicators[i];
+    for (auto& [name, i] : node.indicator_names) {
+      auto& indicator = node.indicators[i];
       try {
         if (units.find(name) != units.end()) {
-          node.indicators[i].set_unit(units[name]);
-          node.indicators[i].set_mean(get_data_value(
+          indicator.set_unit(units[name]);
+          indicator.set_mean(get_data_value(
               name, country, state, county, year, month, units[name]));
-          stdev = 0.1 * abs(indicator.get_mean());
-          node.indicators[i].set_stdev(stdev);
         }
         else {
-          node.indicators[i].set_default_unit();
-          node.indicators[i].set_mean(
+          indicator.set_default_unit();
+          indicator.set_mean(
               get_data_value(name, country, state, county, year, month));
-          stdev = 0.1 * abs(indicator.get_mean());
-          node.indicators[i].set_stdev(stdev);
         }
+          stdev = 0.1 * abs(indicator.get_mean());
+          indicator.set_stdev(stdev);
       }
       catch (logic_error& le) {
         error("AnalysisGraph::parameterize()\n"

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -306,7 +306,7 @@ void AnalysisGraph::find_all_paths_between_util(int start,
     cutoff--;
     // Current vertex is not the destination
     // Recursively process all the vertices adjacent to the current vertex
-    for_each(successors(start), [&](int v) {
+    for_each(this->successors(start), [&](int v) {
       if (!(*this)[v].visited) {
         this->find_all_paths_between_util(v, end, path, cutoff);
       }

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -1796,6 +1796,7 @@ void AnalysisGraph::sample_from_posterior() {
     this->revert_back_to_previous_state();
   }
 }
+
 void AnalysisGraph::set_indicator(string concept,
                                   string indicator,
                                   string source) {

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -144,19 +144,6 @@ void AnalysisGraph::allocate_A_beta_factors() {
   }
 }
 
-void AnalysisGraph::print_A_beta_factors() {
-  int num_verts = boost::num_vertices(this->graph);
-
-  for (int row = 0; row < num_verts; ++row) {
-    for (int col = 0; col < num_verts; ++col) {
-      cout << endl << "Printing cell: (" << row << ", " << col << ") " << endl;
-      if (this->A_beta_factors[row][col]) {
-        this->A_beta_factors[row][col]->print_beta2product();
-      }
-    }
-  }
-}
-
 // TODO: I am creating two methods:
 //    get_subgraph_rooted_at
 //    get_subgraph_sinked_at
@@ -338,6 +325,7 @@ void AnalysisGraph::set_default_initial_state() {
     this->s0_original(i) = 1.0;
   }
 }
+
 int AnalysisGraph::get_vertex_id_for_concept(string concept, string caller) {
   int vert_id = -1;
 
@@ -353,6 +341,7 @@ int AnalysisGraph::get_vertex_id_for_concept(string concept, string caller) {
 
   return vert_id;
 }
+
 int AnalysisGraph::get_degree(int vertex_id) {
   return boost::in_degree(vertex_id, this->graph) +
          boost::out_degree(vertex_id, this->graph);
@@ -845,16 +834,6 @@ void AnalysisGraph::to_png(string filename) {
   gvFreeContext(gvc);
 }
 
-void AnalysisGraph::print_indicators() {
-  for (int v : this->vertices()) {
-    cout << v << ":" << (*this)[v].name << endl;
-    for (auto [name, vert] : (*this)[v].indicator_names) {
-      cout << "\t"
-           << "indicator " << vert << ": " << name << endl;
-    }
-  }
-}
-
 AnalysisGraph
 AnalysisGraph::from_causal_fragments(vector<CausalFragment> causal_fragments) {
   DiGraph G;
@@ -961,15 +940,6 @@ void AnalysisGraph::merge_nodes(string concept_1,
   this->remove_node(vertex_to_remove);
 }
 
-void AnalysisGraph::print_nodes() {
-  print("Vertex IDs and their names in the CAG\n");
-  print("Vertex ID : Name\n");
-  print("--------- : ----\n");
-  for_each(this->vertices(), [&](int v) {
-    cout << v << "         " << this->graph[v].name << endl;
-  });
-}
-
 void AnalysisGraph::set_log_likelihood() {
   this->previous_log_likelihood = this->log_likelihood;
   this->log_likelihood = 0.0;
@@ -1036,6 +1006,15 @@ void AnalysisGraph::find_all_paths() {
   }
 }
 
+void AnalysisGraph::print_nodes() {
+  print("Vertex IDs and their names in the CAG\n");
+  print("Vertex ID : Name\n");
+  print("--------- : ----\n");
+  for_each(this->vertices(), [&](int v) {
+    cout << v << "         " << this->graph[v].name << endl;
+  });
+}
+
 void AnalysisGraph::print_edges() {
   for_each(edges(), [&](auto e) {
     cout << "(" << boost::source(e, this->graph) << ", "
@@ -1043,11 +1022,53 @@ void AnalysisGraph::print_edges() {
   });
 }
 
+void AnalysisGraph::print_indicators() {
+  for (int v : this->vertices()) {
+    cout << v << ":" << (*this)[v].name << endl;
+    for (auto [name, vert] : (*this)[v].indicator_names) {
+      cout << "\t"
+           << "indicator " << vert << ": " << name << endl;
+    }
+  }
+}
+
+void AnalysisGraph::print_all_paths() {
+  int num_verts = boost::num_vertices(this->graph);
+
+  if (this->A_beta_factors.size() != num_verts ||
+      this->A_beta_factors[0].size() != num_verts) {
+    this->find_all_paths();
+  }
+
+  cout << "All the simple paths of:" << endl;
+
+  for (int row = 0; row < num_verts; ++row) {
+    for (int col = 0; col < num_verts; ++col) {
+      if (this->A_beta_factors[row][col]) {
+        this->A_beta_factors[row][col]->print_paths();
+      }
+    }
+  }
+}
+
 void AnalysisGraph::print_name_to_vertex() {
   for (auto [name, vert] : this->name_to_vertex) {
     cout << name << " -> " << vert << endl;
   }
   cout << endl;
+}
+
+void AnalysisGraph::print_A_beta_factors() {
+  int num_verts = boost::num_vertices(this->graph);
+
+  for (int row = 0; row < num_verts; ++row) {
+    for (int col = 0; col < num_verts; ++col) {
+      cout << endl << "Printing cell: (" << row << ", " << col << ") " << endl;
+      if (this->A_beta_factors[row][col]) {
+        this->A_beta_factors[row][col]->print_beta2product();
+      }
+    }
+  }
 }
 
 vector<vector<double>> AnalysisGraph::get_observed_state_from_data(
@@ -1136,25 +1157,6 @@ void AnalysisGraph::change_polarity_of_edge(string source_concept,
     auto e = boost::edge(src_id, tgt_id, this->graph).first;
 
     this->graph[e].change_polarity(source_polarity, target_polarity);
-  }
-}
-
-void AnalysisGraph::print_all_paths() {
-  int num_verts = boost::num_vertices(this->graph);
-
-  if (this->A_beta_factors.size() != num_verts ||
-      this->A_beta_factors[0].size() != num_verts) {
-    this->find_all_paths();
-  }
-
-  cout << "All the simple paths of:" << endl;
-
-  for (int row = 0; row < num_verts; ++row) {
-    for (int col = 0; col < num_verts; ++col) {
-      if (this->A_beta_factors[row][col]) {
-        this->A_beta_factors[row][col]->print_paths();
-      }
-    }
   }
 }
 

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -125,8 +125,8 @@ void AnalysisGraph::parameterize(string country,
           indicator.set_mean(
               get_data_value(name, country, state, county, year, month));
         }
-          stdev = 0.1 * abs(indicator.get_mean());
-          indicator.set_stdev(stdev);
+        stdev = 0.1 * abs(indicator.get_mean());
+        indicator.set_stdev(stdev);
       }
       catch (logic_error& le) {
         error("AnalysisGraph::parameterize()\n"
@@ -1126,8 +1126,8 @@ void AnalysisGraph::add_edge(CausalFragment causal_fragment) {
   }
   else {
     debug("AnalysisGraph::add_edge\n"
-         "\tWARNING: Prevented adding a self loop for the concept {}",
-         subj_name);
+          "\tWARNING: Prevented adding a self loop for the concept {}",
+          subj_name);
   }
 }
 
@@ -1554,8 +1554,6 @@ vector<vector<double>> AnalysisGraph::prediction_to_array(string indicator) {
     }
   }
   // Program will reach here only if the indicator is not found
-  print("AnalysisGraph::prediction_to_array - indicator {} not found!\n",
-        indicator);
   throw IndicatorNotFoundException(format(
       "AnalysisGraph::prediction_to_array - indicator \"{}\" not found!\n",
       indicator));
@@ -1856,11 +1854,11 @@ void AnalysisGraph::replace_indicator(string concept,
 
   if (this->indicators_in_CAG.find(indicator_new) !=
       this->indicators_in_CAG.end()) {
-    print("{0} already exists in Causal Analysis Graph, Indicator {0} did "
-          "not replace Indicator {1} for Concept {2}.",
-          indicator_new,
-          indicator_old,
-          concept);
+    warn("{0} already exists in Causal Analysis Graph, Indicator {0} did "
+         "not replace Indicator {1} for Concept {2}.",
+         indicator_new,
+         indicator_old,
+         concept);
     return;
   }
   try {
@@ -1869,7 +1867,7 @@ void AnalysisGraph::replace_indicator(string concept,
     this->indicators_in_CAG.erase(indicator_old);
   }
   catch (const out_of_range& oor) {
-    error("Error: AnalysisGraph::replace_indicator()\n"
+    error("AnalysisGraph::replace_indicator()\n"
           "\tConcept: {0} is not in the CAG\n"
           "\tIndicator: {1} cannot be replaced",
           concept,

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -1789,7 +1789,7 @@ void AnalysisGraph::sample_from_posterior() {
 
   double acceptance_probability = min(1.0, exp(delta_log_joint_probability));
 
-  if (acceptance_probability < uni_dist(this->rand_num_generator)) {
+  if (acceptance_probability < this->uni_dist(this->rand_num_generator)) {
     // Reject the sample
     this->revert_back_to_previous_state();
   }

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -30,7 +30,8 @@ NEIGHBOR_ITERATOR AnalysisGraph::successors(int i) {
 
 auto AnalysisGraph::nodes() {
   using boost::adaptors::transformed;
-  return this->vertices() | transformed([&](int v) -> auto& {return (*this)[v];});
+  return this->vertices() |
+         transformed([&](int v) -> auto& { return (*this)[v]; });
 }
 
 void AnalysisGraph::map_concepts_to_indicators(int n_indicators) {
@@ -108,8 +109,8 @@ void AnalysisGraph::parameterize(string country,
       try {
         if (units.find(name) != units.end()) {
           (*this)[v].indicators[i].set_unit(units[name]);
-          (*this)[v].indicators[i].set_mean(
-              get_data_value(name, country, state, county, year, month, units[name]));
+          (*this)[v].indicators[i].set_mean(get_data_value(
+              name, country, state, county, year, month, units[name]));
           stdev = 0.1 * abs(indicator.get_mean());
           (*this)[v].indicators[i].set_stdev(stdev);
         }
@@ -969,7 +970,6 @@ void AnalysisGraph::print_nodes() {
   });
 }
 
-
 void AnalysisGraph::set_log_likelihood() {
   this->previous_log_likelihood = this->log_likelihood;
   this->log_likelihood = 0.0;
@@ -1063,15 +1063,19 @@ vector<vector<double>> AnalysisGraph::get_observed_state_from_data(
 
     observed_state[v] = vector<double>(indicators.size(), 0.0);
 
-    transform(
-        indicators.begin(),
-        indicators.end(),
-        observed_state[v].begin(),
-        [&](Indicator ind) {
-          // get_data_value() is defined in data.hpp
-          return get_data_value(
-              ind.get_name(), country, state, county, year, month, ind.get_unit());
-        });
+    transform(indicators.begin(),
+              indicators.end(),
+              observed_state[v].begin(),
+              [&](Indicator ind) {
+                // get_data_value() is defined in data.hpp
+                return get_data_value(ind.get_name(),
+                                      country,
+                                      state,
+                                      county,
+                                      year,
+                                      month,
+                                      ind.get_unit());
+              });
   }
 
   return observed_state;

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -103,29 +103,29 @@ void AnalysisGraph::parameterize(string country,
                                  int month,
                                  map<string, string> units) {
   double stdev;
-  for (int v : this->vertices()) {
-    for (auto [name, i] : (*this)[v].indicator_names) {
-      auto indicator = (*this)[v].indicators[i];
+  for (auto& node : this->nodes()) {
+    for (auto [name, i] : node.indicator_names) {
+      auto indicator = node.indicators[i];
       try {
         if (units.find(name) != units.end()) {
-          (*this)[v].indicators[i].set_unit(units[name]);
-          (*this)[v].indicators[i].set_mean(get_data_value(
+          node.indicators[i].set_unit(units[name]);
+          node.indicators[i].set_mean(get_data_value(
               name, country, state, county, year, month, units[name]));
           stdev = 0.1 * abs(indicator.get_mean());
-          (*this)[v].indicators[i].set_stdev(stdev);
+          node.indicators[i].set_stdev(stdev);
         }
         else {
-          (*this)[v].indicators[i].set_default_unit();
-          (*this)[v].indicators[i].set_mean(
+          node.indicators[i].set_default_unit();
+          node.indicators[i].set_mean(
               get_data_value(name, country, state, county, year, month));
           stdev = 0.1 * abs(indicator.get_mean());
-          (*this)[v].indicators[i].set_stdev(stdev);
+          node.indicators[i].set_stdev(stdev);
         }
       }
       catch (logic_error& le) {
         cerr << "ERROR: AnalysisGraph::parameterize()\n";
         cerr << "\tReading data for:\n";
-        cerr << "\t\tConcept: " << (*this)[v].name << endl;
+        cerr << "\t\tConcept: " << node.name << endl;
         cerr << "\t\tIndicator: " << name << endl;
         rethrow_exception(current_exception());
       }
@@ -461,7 +461,7 @@ AnalysisGraph AnalysisGraph::get_subgraph_for_concept(string concept,
       get_vertex_id_for_concept(concept, "get_subgraph_for_concept()");
 
   // Mark all the vertices are not visited
-  for_each(vertices(), [&](int v) { (*this)[v].visited = false; });
+  for_each(this->vertices(), [&](int v) { (*this)[v].visited = false; });
 
   int num_verts = boost::num_vertices(this->graph);
 
@@ -484,7 +484,7 @@ AnalysisGraph AnalysisGraph::get_subgraph_for_concept(string concept,
   }
 
   // Determine the vertices to be removed
-  for (int vert_id : vertices()) {
+  for (int vert_id : this->vertices()) {
     if (vertices_to_keep.find(vert_id) == vertices_to_keep.end()) {
       vertices_to_remove.insert((*this)[vert_id].name);
     }
@@ -513,7 +513,7 @@ AnalysisGraph AnalysisGraph::get_subgraph_for_concept_pair(
   vector<int> path;
 
   // Mark all the vertices are not visited
-  for_each(vertices(), [&](int v) { (*this)[v].visited = false; });
+  for_each(this->vertices(), [&](int v) { (*this)[v].visited = false; });
 
   this->get_subgraph_between(src_id, tgt_id, path, vertices_to_keep, cutoff);
 
@@ -527,7 +527,7 @@ AnalysisGraph AnalysisGraph::get_subgraph_for_concept_pair(
   }
 
   // Determine the vertices to be removed
-  for (int vert_id : vertices()) {
+  for (int vert_id : this->vertices()) {
     if (vertices_to_keep.find(vert_id) == vertices_to_keep.end()) {
       vertices_to_remove.insert((*this)[vert_id].name);
     }

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -64,7 +64,7 @@ class AnalysisGraph {
 
   // Maps each concept name to the vertex id of the
   // vertex that concept is represented in the CAG
-  // concept name --> CAV vertex id
+  // concept name --> CAG vertex id
   std::unordered_map<std::string, int> name_to_vertex = {};
 
   // Keeps track of indicators in CAG to ensure there are no duplicates.

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -180,9 +180,6 @@ class AnalysisGraph {
   double log_likelihood = 0.0;
   double previous_log_likelihood = 0.0;
 
-  AnalysisGraph(DiGraph G, std::unordered_map<std::string, int> name_to_vertex)
-      : graph(G), name_to_vertex(name_to_vertex){};
-
   void
   get_subgraph_rooted_at(int vert,
                          std::unordered_set<int>& vertices_to_keep,

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -11,7 +11,7 @@
 #include "tran_mat_cell.hpp"
 #include <fmt/format.h>
 
-const size_t DEFAULT_N_SAMPLES = 100;
+const size_t DEFAULT_N_SAMPLES = 200;
 
 enum InitialBeta { ZERO, ONE, HALF, MEAN, RANDOM };
 
@@ -24,6 +24,15 @@ typedef std::pair<std::tuple<std::string, int, std::string>,
                   std::tuple<std::string, int, std::string>>
     CausalFragment;
 
+typedef std::vector<std::vector<
+    std::unordered_map<std::string, std::unordered_map<std::string, double>>>>
+    FormattedPredictionResult;
+
+typedef std::tuple<std::pair<std::pair<int, int>, std::pair<int, int>>,
+                   std::vector<std::string>,
+                   FormattedPredictionResult>
+    Prediction;
+
 AdjectiveResponseMap construct_adjective_response_map(size_t n_kernels);
 
 /**
@@ -34,7 +43,7 @@ class AnalysisGraph {
 
   public:
   AnalysisGraph() {}
-  Node &operator[] (std::string);
+  Node& operator[](std::string);
   Edge& edge(int, int);
   auto nodes();
 
@@ -50,9 +59,8 @@ class AnalysisGraph {
   void print_A_beta_factors();
 
   private:
-
-  Node &operator[] (int);
-  void clear_state(); 
+  Node& operator[](int);
+  void clear_state();
 
   // Maps each concept name to the vertex id of the
   // vertex that concept is represented in the CAG
@@ -105,7 +113,7 @@ class AnalysisGraph {
 
   int n_timesteps;
   int pred_timesteps;
-  std::pair<std::pair<int,int>,std::pair<int,int>> training_range;
+  std::pair<std::pair<int, int>, std::pair<int, int>> training_range;
 
   // Accumulates the transition matrices for accepted samples
   // Access: [ sample number ]
@@ -134,7 +142,7 @@ class AnalysisGraph {
   std::vector<ObservedStateSequence> predicted_observed_state_sequences;
 
   // Sampling resolution. Default is 200
-  int res = 200;
+  int res = DEFAULT_N_SAMPLES;
 
   // Training start
   int init_training_year;
@@ -558,15 +566,10 @@ class AnalysisGraph {
    * predicted values. Access it as: [ sample number ][ time point ][ vertex
    * name ][ indicator name ]
    */
-  std::tuple<std::pair<std::pair<int,int>,std::pair<int,int>>,
-            std::vector<std::string>,
-            std::vector<std::vector<
-                std::unordered_map<std::string,
-                                   std::unordered_map<std::string, double>>>>>
-  generate_prediction(int start_year,
-                      int start_month,
-                      int end_year,
-                      int end_month);
+  Prediction generate_prediction(int start_year,
+                                 int start_month,
+                                 int end_year,
+                                 int end_month);
 
   /**
    * Format the prediction result into a format python callers favor.
@@ -577,9 +580,8 @@ class AnalysisGraph {
    *         Access it as:
    *         [ sample number ][ time point ][ vertex name ][ indicator name ]
    */
-  std::vector<std::vector<
-      std::unordered_map<std::string, std::unordered_map<std::string, double>>>>
-  format_prediction_result();
+
+  FormattedPredictionResult format_prediction_result();
 
   /**
    * this->generate_prediction() must be called before callign this method.
@@ -606,11 +608,7 @@ class AnalysisGraph {
   void
   generate_synthetic_observed_state_sequence_from_synthetic_latent_state_sequence();
 
-  std::pair<ObservedStateSequence,
-            std::tuple<std::pair<std::pair<int,int>,std::pair<int,int>>,std::vector<std::string>,
-                      std::vector<std::vector<std::unordered_map<
-                          std::string,
-                          std::unordered_map<std::string, double>>>>>>
+  std::pair<ObservedStateSequence, Prediction>
   test_inference_with_synthetic_data(
       int start_year = 2015,
       int start_month = 1,

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -114,24 +114,24 @@ class AnalysisGraph {
   // Accumulates the latent states for accepted samples
   // Access this as
   // latent_state_sequences[ sample ][ time step ]
-  std::vector<std::vector<Eigen::VectorXd>> training_latent_state_sequence_s;
+  std::vector<std::vector<Eigen::VectorXd>> training_latent_state_sequences;
 
   // This is a column of the
-  // this->training_latent_state_sequence_s
+  // this->training_latent_state_sequences
   // prediction_initial_latent_state_s.size() = this->res
   // TODO: If we make the code using this variable to directly fetch the values
-  // from this->training_latent_state_sequence_s, we can get rid of this
+  // from this->training_latent_state_sequences, we can get rid of this
   std::vector<Eigen::VectorXd> prediction_initial_latent_state_s;
   std::vector<std::string> pred_range;
 
   // Access this as
-  // prediction_latent_state_sequence_s[ sample ][ time step ]
-  std::vector<std::vector<Eigen::VectorXd>> predicted_latent_state_sequence_s;
+  // prediction_latent_state_sequences[ sample ][ time step ]
+  std::vector<std::vector<Eigen::VectorXd>> predicted_latent_state_sequences;
 
   // Access this as
-  // prediction_observed_state_sequence_s
+  // prediction_observed_state_sequences
   //                            [ sample ][ time step ][ vertex ][ indicator ]
-  std::vector<ObservedStateSequence> predicted_observed_state_sequence_s;
+  std::vector<ObservedStateSequence> predicted_observed_state_sequences;
 
   // Sampling resolution. Default is 200
   int res = 200;
@@ -530,13 +530,13 @@ class AnalysisGraph {
    *
    * @param timesteps: The number of timesteps for the sequences.
    */
-  void sample_predicted_latent_state_sequence_s_from_likelihood(int timesteps);
+  void sample_predicted_latent_state_sequences(int timesteps);
 
   /** Generate predicted observed state sequenes given predicted latent state
    * sequences using the emission model
    */
   void
-  generate_predicted_observed_state_sequence_s_from_predicted_latent_state_sequence_s();
+  generate_predicted_observed_state_sequences_from_predicted_latent_state_sequences();
 
   /**
    * Given a trained model, generate this->res number of
@@ -601,7 +601,7 @@ class AnalysisGraph {
   // ObservedStateSequence synthetic_observed_state_sequence;
   bool synthetic_data_experiment = false;
 
-  void generate_synthetic_latent_state_sequence_from_likelihood();
+  void generate_synthetic_latent_state_sequence();
 
   void
   generate_synthetic_observed_state_sequence_from_synthetic_latent_state_sequence();

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -36,6 +36,7 @@ class AnalysisGraph {
   AnalysisGraph() {}
   Node &operator[] (std::string);
   Edge& edge(int, int);
+  auto nodes();
 
   // Manujinda: I had to move this up since I am usign this within the private:
   // block This is ugly. We need to re-factor the code to make it pretty again

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -126,10 +126,10 @@ class AnalysisGraph {
 
   // This is a column of the
   // this->training_latent_state_sequences
-  // prediction_initial_latent_state_s.size() = this->res
+  // prediction_initial_latent_states.size() = this->res
   // TODO: If we make the code using this variable to directly fetch the values
   // from this->training_latent_state_sequences, we can get rid of this
-  std::vector<Eigen::VectorXd> prediction_initial_latent_state_s;
+  std::vector<Eigen::VectorXd> prediction_initial_latent_states;
   std::vector<std::string> pred_range;
 
   // Access this as

--- a/lib/data.cpp
+++ b/lib/data.cpp
@@ -19,7 +19,7 @@ double get_data_value(std::string indicator,
   int rc = sqlite3_open(getenv("DELPHI_DB"), &db);
 
   if (rc) {
-    spdlog::error("Could not open db");
+    error("Could not open db");
     return 0.0;
   }
 

--- a/lib/data.cpp
+++ b/lib/data.cpp
@@ -1,7 +1,6 @@
 #include "data.hpp"
 #include <sqlite3.h>
 
-
 double get_data_value(std::string indicator,
                       std::string country,
                       std::string state,
@@ -13,7 +12,7 @@ double get_data_value(std::string indicator,
   using namespace std;
   using fmt::print;
   using namespace fmt::literals;
-  using spdlog::debug, spdlog::error;
+  using spdlog::debug, spdlog::error, spdlog::info;
 
   sqlite3* db;
   int rc = sqlite3_open(getenv("DELPHI_DB"), &db);
@@ -46,7 +45,7 @@ double get_data_value(std::string indicator,
     sqlite3_finalize(stmt);
   }
   else {
-    query = "{} and `Country` is 'None'"_format(query); 
+    query = "{} and `Country` is 'None'"_format(query);
   }
 
   if (!state.empty()) {
@@ -112,9 +111,9 @@ double get_data_value(std::string indicator,
         sqlite3_finalize(stmt);
       }
       else {
-        cerr << "Error: data::get_data_value()\n"
-             << "\tIndicator: No data exists for indicator " << indicator
-             << endl;
+        error("data::get_data_value()\n"
+              "\tIndicator: No data exists for indicator {}",
+              indicator);
 
         // Should define an exception to throw in this situation
         sqlite3_finalize(stmt);
@@ -137,8 +136,9 @@ double get_data_value(std::string indicator,
       sqlite3_finalize(stmt);
     }
     else {
-      cerr << "Error: data::get_data_value()\n"
-           << "\tIndicator: No data exists for " << indicator << endl;
+      error("data::get_data_value()\n"
+            "\tIndicator: No data exists for {}",
+            indicator);
 
       // Should define an exception to throw in this situation
       sqlite3_finalize(stmt);
@@ -167,7 +167,7 @@ double get_data_value(std::string indicator,
   }
 
   else {
-    debug("No data found for {0},{1}. Averaging over all months for {1} "
+    info("No data found for {0}, {1}. Averaging over all months for {1} "
           "(Default Setting)\n",
           month,
           year);
@@ -208,7 +208,7 @@ double get_data_value(std::string indicator,
 
   sqlite3_finalize(stmt);
   sqlite3_close(db);
-  spdlog::error("data::get_data_value()\n\tIndicator: No data exists for {}");
+  error("data::get_data_value()\n\tIndicator: No data exists for {}");
   // Should define an exception to throw in this situation
   return 0.0;
 }

--- a/lib/train_model.cpp
+++ b/lib/train_model.cpp
@@ -64,8 +64,8 @@ void AnalysisGraph::train_model(int start_year,
   // Accumulates the latent states for accepted samples
   // Access this as
   // latent_state_sequences[ sample ][ time step ]
-  this->training_latent_state_sequence_s.clear();
-  this->training_latent_state_sequence_s =
+  this->training_latent_state_sequences.clear();
+  this->training_latent_state_sequences =
       vector<vector<Eigen::VectorXd>>(this->res);
 
   for (int i : trange(burn)) {
@@ -76,7 +76,7 @@ void AnalysisGraph::train_model(int start_year,
     this->sample_from_posterior();
     // this->training_sampled_transition_matrix_sequence[samp] =
     this->transition_matrix_collection[i] = this->A_original;
-    this->training_latent_state_sequence_s[i] = this->latent_state_sequence;
+    this->training_latent_state_sequences[i] = this->latent_state_sequence;
   }
 
   this->trained = true;

--- a/lib/train_model.cpp
+++ b/lib/train_model.cpp
@@ -1,8 +1,10 @@
 #include "AnalysisGraph.hpp"
+#include "spdlog/spdlog.h"
 #include <tqdm.hpp>
 
 using namespace std;
 using tq::trange;
+using spdlog::debug;
 
 void AnalysisGraph::train_model(int start_year,
                                 int start_month,
@@ -26,7 +28,7 @@ void AnalysisGraph::train_model(int start_year,
   this->sample_initial_transition_matrix_from_prior();
   this->parameterize(country, state, county, start_year, start_month, units);
 
-  this->training_range = make_pair(make_pair(start_year,start_month),make_pair(end_year,end_month));
+  this->training_range = make_pair(make_pair(start_year,start_month), make_pair(end_year,end_month));
   this->init_training_year = start_year;
   this->init_training_month = start_month;
 
@@ -47,7 +49,7 @@ void AnalysisGraph::train_model(int start_year,
   //
   // generate_prediction()      uses
   // sample_from_likelihood. It uses
-  // transition_mateix_collection
+  // transition_matrix_collection
   // So to keep things simple for the moment
   // I had to fall back to
   // transition_matrix_collection
@@ -74,12 +76,10 @@ void AnalysisGraph::train_model(int start_year,
 
   for (int i : trange(this->res)) {
     this->sample_from_posterior();
-    // this->training_sampled_transition_matrix_sequence[samp] =
     this->transition_matrix_collection[i] = this->A_original;
     this->training_latent_state_sequences[i] = this->latent_state_sequence;
   }
 
   this->trained = true;
-  fmt::print("\n");
   return;
 }

--- a/tests/cpptests.cpp
+++ b/tests/cpptests.cpp
@@ -30,9 +30,7 @@ TEST_CASE("Testing model training") {
   G.construct_beta_pdfs();
   G.train_model(2015, 1, 2015, 12, 100, 900);
 
-  tuple<pair<pair<int,int>,pair<int,int>>,vector<string>,
-       vector<vector<unordered_map<string, unordered_map<string, double>>>>>
-      preds = G.generate_prediction(2015, 1, 2015, 12);
+  Prediction preds = G.generate_prediction(2015, 1, 2015, 12);
   fmt::print("Prediction to array\n");
 
   try {

--- a/tests/cpptests.cpp
+++ b/tests/cpptests.cpp
@@ -20,12 +20,12 @@ TEST_CASE("Testing model training") {
   AnalysisGraph G = AnalysisGraph::from_causal_fragments(causal_fragments);
 
   G.map_concepts_to_indicators();
+  G.to_png();
 
   G.replace_indicator("UN/events/human/human_migration",
                       "Net migration",
                       "New asylum seeking applicants",
                       "UNHCR");
-  G.to_png();
 
   G.construct_beta_pdfs();
   G.train_model(2015, 1, 2015, 12, 100, 900);

--- a/tests/wm/test_cpp_evaluation.py
+++ b/tests/wm/test_cpp_evaluation.py
@@ -1,4 +1,5 @@
 from delphi.cpp.DelphiPython import AnalysisGraph, InitialBeta
+from delphi.evaluation_port import pred_plot
 import pytest
 from matplotlib import pyplot as plt
 from tqdm import trange
@@ -14,18 +15,14 @@ def test_cpp_extensions():
         )
     ]
     G = AnalysisGraph.from_causal_fragments(statements)
-    print("\n")
-    G.print_nodes()
     G.map_concepts_to_indicators()
-    G.print_indicators()
-    print("\n")
     G.replace_indicator(
         "UN/events/human/human_migration",
         "Net migration",
         "New asylum seeking applicants",
         "UNHCR",
     )
-    G.print_indicators()
+    G.to_png()
 
     # Now we can specify how to initialize betas. Posible values are:
     # InitialBeta.ZERO
@@ -36,14 +33,7 @@ def test_cpp_extensions():
     G.construct_beta_pdfs()
     G.train_model(2015, 1, 2015, 12, 1000, 10000, initial_beta=InitialBeta.ZERO)
     preds = G.generate_prediction(2015, 1, 2016, 12)
-    print(len(preds[0]))
-    print(len(preds[1]))
-    print(len(preds[1][0]))
-    print(preds[0])
-    predicted_point = preds[1][0]
-    for ts in predicted_point:
-        print(ts)
-    print("\n")
+    pred_plot(preds, "New asylum seeking applicants", save_as="pred_plot.pdf")
 
 def test_delete_indicator():
     statements = [


### PR DESCRIPTION
This PR:

- Adds more explicit tracking of dependencies in CMakeLists.txt to comply with CMake bests practices.
- Reintroduces the nodes() iterator, fixing the bug with the earlier implementation where copies of Node objects were being returned rather than references. You can now iterate over nodes with 
  ```c++
  for (auto& n : this->nodes()) {...}
  ```
- Miscellaneous code cleanup, including adding typedefs for increased readability