### PR TITLE
Running Travis with Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,15 @@ python:
 before_install:
   - docker pull pauldhein/project-containers:delphi
   - docker run -itd --name delphi pauldhein/project-containers
-  - docker exec delphi git clone https://github.com/ml4ai/delphi.git /repo
+  - docker exec delphi git clone https://github.com/$TRAVIS_REPO_SLUG.git /$TRAVIS_REPO_SLUG
+  - docker exec delphi cd /$TRAVIS_REPO_SLUG
+  - docker exec delphi git checkout -qf $TRAVIS_COMMIT
 
 script:
-  - make test
-  - cd /repo/delphi/docs; make apidocs; make html
+  - docker exec delphi make test
+  - docker exec delphi cd /$TRAVIS_REPO_SLUG/delphi/docs
+  - docker exec delphi make apidocs
+  - docker exec delphi make html
 
 deploy:
   local-dir: docs/_build/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,11 @@ before_install:
   - docker pull pauldhein/project-containers:delphi
   - docker run -itd --name delphi pauldhein/project-containers
   - docker exec delphi git clone https://github.com/$TRAVIS_REPO_SLUG.git /$TRAVIS_REPO_SLUG
-  - docker exec delphi cd /$TRAVIS_REPO_SLUG
-  - docker exec delphi git checkout -qf $TRAVIS_COMMIT
+  - docker run delphi /bin/sh -c "cd /$TRAVIS_REPO_SLUG; git checkout -qf $TRAVIS_COMMIT"
 
 script:
   - docker exec delphi make test
-  - docker exec delphi cd /$TRAVIS_REPO_SLUG/delphi/docs
-  - docker exec delphi make apidocs
-  - docker exec delphi make html
+  - docker run delphi /bin/sh -c  "cd /$TRAVIS_REPO_SLUG/delphi/docs; make apidocs; make html"
 
 deploy:
   local-dir: docs/_build/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-dist: xenial
-language: 
+sudo: required
+language:
  - python
  - cpp
+
+services:
+  - docker
 
 compiler:
   - gcc
@@ -17,7 +20,7 @@ addons:
     - g++-8
     - graphviz
     - doxygen
-    - sqlite3 
+    - sqlite3
     - libsqlite3-dev
     - libboost-all-dev
     - libeigen3-dev
@@ -32,9 +35,20 @@ install:
   # Set the environment variable DELPHI_DB to point to the SQLite3 database.
   - export DELPHI_DB=`pwd`/delphi.db
 
+before_install:
+  - docker pull qbradq/example-build:latest
+  - docker run -itd --name delphi qbradq/example-build
+  - docker exec build git clone https://github.com/qbradq/docker-build-example.git /repo
+
+before_install:
+  - docker build -t delphi .
+  - docker run -d -p 127.0.0.1:80:4567 delphi /bin/sh -c "cd /repo/delphi; make test;"
+  - docker ps -a
+  - docker run delphi /bin/sh -c "cd /repo/delphi; make test"
+  - docker run delphi /bin/sh -c "cd /repo/delphi/docs; make apidocs; make html"
 script:
   - make test
-  - cd docs; make apidocs; make html
+  - cd /repo/delphi/docs; make apidocs; make html
 
 deploy:
   local-dir: docs/_build/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,40 +12,11 @@ compiler:
 python:
   - "3.6"
 
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-8
-    - graphviz
-    - doxygen
-    - sqlite3
-    - libsqlite3-dev
-    - libboost-all-dev
-    - libeigen3-dev
-
-install:
-  - export CC=gcc-8
-  - export CXX=g++-8
-  - pip install cython
-  - pip install -e .[test,docs]
-  # Download SQLite3 database containing model parameterization data.
-  - curl -O http://vanga.sista.arizona.edu/delphi_data/delphi.db
-  # Set the environment variable DELPHI_DB to point to the SQLite3 database.
-  - export DELPHI_DB=`pwd`/delphi.db
-
 before_install:
-  - docker pull qbradq/example-build:latest
-  - docker run -itd --name delphi qbradq/example-build
-  - docker exec build git clone https://github.com/qbradq/docker-build-example.git /repo
+  - docker pull pauldhein/project-containers:delphi
+  - docker run -itd --name delphi pauldhein/project-containers
+  - docker exec delphi git clone https://github.com/ml4ai/delphi.git /repo
 
-before_install:
-  - docker build -t delphi .
-  - docker run -d -p 127.0.0.1:80:4567 delphi /bin/sh -c "cd /repo/delphi; make test;"
-  - docker ps -a
-  - docker run delphi /bin/sh -c "cd /repo/delphi; make test"
-  - docker run delphi /bin/sh -c "cd /repo/delphi/docs; make apidocs; make html"
 script:
   - make test
   - cd /repo/delphi/docs; make apidocs; make html

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ RUN apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN add-apt-repository ppa:jonathonf/python-3.6
 RUN apt-get update && apt-get -y install \
-  apt-utils build-essential g++-8 curl git tar wget \
-  python3.6 python3.6-dev python3-pip python3.6-venv \
-  doxygen graphviz sqlite3 \
+  apt-utils build-essential g++-8 curl git tar wget
+
+
+RUN apt-get -y install python3.6 python3.6-dev python3-pip python3.6-venv \
+  doxygen graphviz sqlite3 openjdk-8-jdk \
   libsqlite3-dev libboost-all-dev libeigen3-dev
 
 # Setup the correct version of Python and install/update pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ RUN apt-get update && apt-get install -y software-properties-common
 # Required system packages
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN add-apt-repository ppa:jonathonf/python-3.6
-RUN apt-get update && apt-get -y install \
-  apt-utils build-essential g++-8 curl git tar wget
+RUN apt-get update
+RUN apt-get -y install apt-utils build-essential g++-8 curl git tar wget time
 
 
-RUN apt-get -y install python3.6 python3.6-dev python3-pip python3.6-venv \
-  doxygen graphviz sqlite3 openjdk-8-jdk \
-  libsqlite3-dev libboost-all-dev libeigen3-dev
+RUN apt-get -y install python3.6 python3.6-dev python3-pip python3.6-venv
+RUN apt-get -y install doxygen openjdk-8-jdk graphviz libgraphviz-dev pkg-config
+RUN apt-get -y install sqlite3 libsqlite3-dev libboost-all-dev libeigen3-dev
 
 # Setup the correct version of Python and install/update pip
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
@@ -36,4 +36,5 @@ RUN git clone https://github.com/ml4ai/delphi.git
 
 WORKDIR /repo/delphi
 RUN pip install cython
+RUN pip install cmake
 RUN pip install -e .[test,docs]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM        ubuntu:16.04
+MAINTAINER  Paul D. Hein <pauldhein@email.arizona.edu>
+CMD         bash
+
+RUN apt-get update && apt-get install -y software-properties-common
+# Required system packages
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN add-apt-repository ppa:jonathonf/python-3.6
+RUN apt-get update && apt-get -y install \
+  apt-utils build-essential g++-8 curl git tar wget \
+  python3.6 python3.6-dev python3-pip python3.6-venv \
+  doxygen graphviz sqlite3 \
+  libsqlite3-dev libboost-all-dev libeigen3-dev
+
+# Setup the correct version of Python and install/update pip
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 2
+RUN curl https://bootstrap.pypa.io/ez_setup.py -o - | python3.6 && python3.6 -m easy_install pip
+RUN pip install pip --upgrade && pip install wheel
+
+RUN mkdir -p /data /repo
+WORKDIR /data
+# Download SQLite3 database containing model parameterization data.
+RUN curl -O http://vanga.sista.arizona.edu/delphi_data/delphi.db
+
+# Set the environment variable DELPHI_DB to point to the SQLite3 database.
+ENV DELPHI_DB=/data/delphi.db
+
+# Build the delphi testing environment
+ENV CC=gcc-8
+ENV CXX=g++-8
+WORKDIR /repo
+RUN git clone https://github.com/ml4ai/delphi.git
+
+WORKDIR /repo/delphi
+RUN pip install cython
+RUN pip install -e .[test,docs]

--- a/delphi/apps/CodeExplorer/Dockerfile
+++ b/delphi/apps/CodeExplorer/Dockerfile
@@ -1,3 +1,5 @@
+# NOTE: This dockerfile is intended to be run from the root of the delphi repo
+
 # Use an official Python runtime as a parent image
 from python:3.6
 run apt-get update; apt-get install -y openjdk-8-jre


### PR DESCRIPTION
This PR changes the build process of Travis CI for the delphi repo to utilize a pre-built docker image for delphi hosted on docker hub. This PR may not be passing the build immediately, and likely will require inspection by myself and @adarshp but we need to get the process started via Travis testing of the PR.