### PR TITLE
Improvements to create_model executable, plus other QOL improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Graphviz)
 
 include_directories(${GRAPHVIZ_INCLUDE_DIRS})
 # Add and link pybind11 modules
-find_package(Boost REQUIRED)
+find_package(Boost COMPONENTS program_options REQUIRED)
 include_directories(lib)
 include_directories(external)
 include_directories(${Boost_INCLUDE_DIR})

--- a/apps/create_model.cpp
+++ b/apps/create_model.cpp
@@ -2,14 +2,49 @@
 
 #include "AnalysisGraph.hpp"
 #include "spdlog/spdlog.h"
-
-using namespace std;
+#include <boost/program_options.hpp>
 
 int main(int argc, char* argv[]) {
+  using namespace std;
+  using namespace boost::program_options;
+
+  options_description desc("Allowed options");
+  positional_options_description pd;
+
+  // Path to JSON-serialized INDRA statements
+  string stmts;
+
+  desc.add_options()
+    ("help,h", "Executable for creating Delphi models")
+    ("stmts", value<string>(&stmts), "Path to JSON-serialized INDRA statements")
+    ("belief_score_cutoff", value<double>()->default_value(0.9),
+     "INDRA belief score cutoff for statements to be included in the model.")
+    ("grounding_score_cutoff", value<double>()->default_value(0.7),
+     "Grounding score cutoff for statements to be included in the model")
+  ;
+
+  // Setting positional arguments
+  pd.add("stmts", 1);
+  pd.add("belief_score_cutoff", 2);
+  pd.add("grounding_score_cutoff", 3);
+
+  variables_map vm;
+  store(parse_command_line(argc, argv, desc), vm);
+  notify(vm);
+
+  if (vm.count("help") || argc == 1) {
+    cout << desc << endl;
+    return 1;
+  }
+
   RNG *R = RNG::rng();
   R->set_seed(87);
   spdlog::set_level(spdlog::level::debug);
-  auto G = AnalysisGraph::from_json_file(argv[1], 0.9, 0.0);
+  auto G = AnalysisGraph::from_json_file(
+      stmts,
+      vm["belief_score_cutoff"].as<double>(), 
+      vm["grounding_score_cutoff"].as<double>());
+
   G.map_concepts_to_indicators();
   G.construct_beta_pdfs();
   G.to_png();

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -48,6 +48,8 @@ class AnalysisGraph {
   AnalysisGraph() {}
   Node& operator[](std::string);
   Edge& edge(int, int);
+  size_t num_vertices();
+  size_t num_edges();
   auto nodes();
 
   // Manujinda: I had to move this up since I am usign this within the private:
@@ -732,11 +734,11 @@ class AnalysisGraph {
 
   void print_name_to_vertex();
 
-  std::pair<Agraph_t*, GVC_t*> to_agraph();
+  std::pair<Agraph_t*, GVC_t*> to_agraph(bool simplified_labels = false);
 
   std::string to_dot();
 
-  void to_png(std::string filename = "CAG.png");
+  void to_png(std::string filename = "CAG.png", bool simplified_labels = false);
 
   void print_indicators();
 };

--- a/lib/wrappers/AnalysisGraph_wrapper.cpp
+++ b/lib/wrappers/AnalysisGraph_wrapper.cpp
@@ -46,7 +46,7 @@ PYBIND11_MODULE(DelphiPython, m) {
       .def("print_edges", &AnalysisGraph::print_edges)
       .def("print_name_to_vertex", &AnalysisGraph::print_name_to_vertex)
       .def("to_dot", &AnalysisGraph::to_dot)
-      .def("to_png", &AnalysisGraph::to_png, "filename"_a = "CAG.png")
+      .def("to_png", &AnalysisGraph::to_png, "filename"_a = "CAG.png", "simplified_labels"_a = true)
       .def("construct_beta_pdfs", &AnalysisGraph::construct_beta_pdfs)
       .def("add_node", &AnalysisGraph::add_node, "concept"_a)
       .def("remove_node",


### PR DESCRIPTION
This PR implements the following.

* The create_model executable now has a number of additional options to help iteratively build CAGs at the command line.
* A first cut at simplified CAG labels for the Graphviz visualization has been implemented (attn: @manujinda )
* Added `num_vertices` and `num_edges` methods to AnalysisGraph that wrap the corresponding BGL functions.