### PR TITLE
Original SIR-Gillespie_SD GrFN

### DIFF
--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -1927,38 +1927,36 @@ class GrFNGenerator(object):
                 for functions in self.function_argument_map:
                     if self.function_argument_map[functions]["name"] == \
                             function["function"]["name"]:
-                        for updated in self.function_argument_map[
-                                functions]["updated_list"]:
-                            (_, variable_name, _) = updated.split('::')
 
-                            for var in function["input"]:
-                                input_var = var.rsplit('::')
-                                # DEBUG
-                                print ("input_var: ", input_var)
-                                index = input_var[2]
-                                if (
-                                        variable_name is not input_var[1]
-                                        and input_var[1] in self.f_array_arg
-                                ):
-                                    variable_name = input_var[1]
-                                    # DEBUG
-                                    print ("variable_name: ", variable_name)
+                        for var in function["input"]:
+                            input_var = var.rsplit('::')
                             # DEBUG
-                            print ("    self.f_array_arg: ", self.f_array_arg)
-                            function["updated"].append(
-                                f"@variable::{variable_name}::{int(index)+1}"
-                            )
+                            print ("input_var: ", input_var)
+                            index = input_var[2]
+                            if (
+                                input_var[1] in self.f_array_arg
+                                or var in self.function_argument_map[functions]["updated_list"]
+                            ):
+                                variable_name = input_var[1]
+                                # DEBUG
+                                print ("variable_name: ", variable_name)
 
-                            state.last_definitions[variable_name] += 1
-                            state.next_definitions[variable_name] = \
-                                state.last_definitions[variable_name] + 1
+                                # DEBUG
+                                print ("    self.f_array_arg: ", self.f_array_arg)
+                                function["updated"].append(
+                                    f"@variable::{variable_name}::{int(index)+1}"
+                                )
 
-                            variable_spec = self.generate_variable_definition(
-                                variable_name,
-                                None,
-                                state
-                            )
-                            grfn['variables'].append(variable_spec)
+                                state.last_definitions[variable_name] += 1
+                                state.next_definitions[variable_name] = \
+                                    state.last_definitions[variable_name] + 1
+
+                                variable_spec = self.generate_variable_definition(
+                                    variable_name,
+                                    None,
+                                    state
+                                )
+                                grfn['variables'].append(variable_spec)
             # Keep a track of all functions whose `update` might need to be
             # later updated, along with their scope.
             if len(function['input']) > 0:

--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -1811,8 +1811,6 @@ class GrFNGenerator(object):
 
             argument_list = []
             list_index = 0
-            # DEBUG
-            print ("call: ", call)
             for arg in call["inputs"]:
                 generate_lambda_for_arr = False
                 if len(arg) == 1:
@@ -1930,19 +1928,12 @@ class GrFNGenerator(object):
 
                         for var in function["input"]:
                             input_var = var.rsplit('::')
-                            # DEBUG
-                            print ("input_var: ", input_var)
                             index = input_var[2]
                             if (
                                 input_var[1] in self.f_array_arg
                                 or var in self.function_argument_map[functions]["updated_list"]
                             ):
                                 variable_name = input_var[1]
-                                # DEBUG
-                                print ("variable_name: ", variable_name)
-
-                                # DEBUG
-                                print ("    self.f_array_arg: ", self.f_array_arg)
                                 function["updated"].append(
                                     f"@variable::{variable_name}::{int(index)+1}"
                                 )

--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -421,6 +421,7 @@ class GrFNGenerator(object):
         # container body
         container_variables = argument_variable_grfn + function_variable_grfn
         # Find the list of updated identifiers
+        # TODO: CHECK HERE
         if argument_list:
             updated_identifiers = self._find_updated(argument_variable_grfn,
                                                      function_variable_grfn,
@@ -1927,14 +1928,25 @@ class GrFNGenerator(object):
                 for functions in self.function_argument_map:
                     if self.function_argument_map[functions]["name"] == \
                             function["function"]["name"]:
+                        # DEBUG
+                        print ("self.function_argument_map: ", self.function_argument_map)
                         for updated in self.function_argument_map[
                                 functions]["updated_list"]:
+                            # DEBUG
+                            print ("    updated: ", updated)
                             (_, variable_name, _) = updated.split('::')
+                            print ("    variable_name: ", variable_name)
+                            # DEBUG
+                            print ("    function[input]: ", function["input"])
+                            for var in function["input"]:
+                                print ("        var: ", var)
+                                index = var.rsplit('::', 1)[1]
+                            """
                             index = [
                                 var.rsplit('::', 1)[1]
                                 for var in function["input"]
                                 if variable_name in var
-                            ][0]
+                            ][0]"""
                             function["updated"].append(
                                 f"@variable::{variable_name}::{int(index)+1}"
                             )
@@ -1957,6 +1969,8 @@ class GrFNGenerator(object):
                     "state": state
                 }
             grfn["functions"].append(function)
+
+            print ("    Final GrFN: ", grfn, "\n")
         return [grfn]
 
     def process_compare(self, node, state, *_):

--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -421,7 +421,6 @@ class GrFNGenerator(object):
         # container body
         container_variables = argument_variable_grfn + function_variable_grfn
         # Find the list of updated identifiers
-        # TODO: CHECK HERE
         if argument_list:
             updated_identifiers = self._find_updated(argument_variable_grfn,
                                                      function_variable_grfn,
@@ -1812,6 +1811,8 @@ class GrFNGenerator(object):
 
             argument_list = []
             list_index = 0
+            # DEBUG
+            print ("call: ", call)
             for arg in call["inputs"]:
                 generate_lambda_for_arr = False
                 if len(arg) == 1:
@@ -1931,11 +1932,23 @@ class GrFNGenerator(object):
                             (_, variable_name, _) = updated.split('::')
 
                             for var in function["input"]:
-                                index = var.rsplit('::', 1)[1]
-
+                                input_var = var.rsplit('::')
+                                # DEBUG
+                                print ("input_var: ", input_var)
+                                index = input_var[2]
+                                if (
+                                        variable_name is not input_var[1]
+                                        and input_var[1] in self.f_array_arg
+                                ):
+                                    variable_name = input_var[1]
+                                    # DEBUG
+                                    print ("variable_name: ", variable_name)
+                            # DEBUG
+                            print ("    self.f_array_arg: ", self.f_array_arg)
                             function["updated"].append(
                                 f"@variable::{variable_name}::{int(index)+1}"
                             )
+
                             state.last_definitions[variable_name] += 1
                             state.next_definitions[variable_name] = \
                                 state.last_definitions[variable_name] + 1
@@ -1955,7 +1968,6 @@ class GrFNGenerator(object):
                     "state": state
                 }
             grfn["functions"].append(function)
-
         return [grfn]
 
     def process_compare(self, node, state, *_):

--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -1812,8 +1812,6 @@ class GrFNGenerator(object):
 
             argument_list = []
             list_index = 0
-            # DEBUG
-            print ("call: ", call)
             for arg in call["inputs"]:
                 generate_lambda_for_arr = False
                 if len(arg) == 1:
@@ -1928,25 +1926,13 @@ class GrFNGenerator(object):
                 for functions in self.function_argument_map:
                     if self.function_argument_map[functions]["name"] == \
                             function["function"]["name"]:
-                        # DEBUG
-                        print ("self.function_argument_map: ", self.function_argument_map)
                         for updated in self.function_argument_map[
                                 functions]["updated_list"]:
-                            # DEBUG
-                            print ("    updated: ", updated)
                             (_, variable_name, _) = updated.split('::')
-                            print ("    variable_name: ", variable_name)
-                            # DEBUG
-                            print ("    function[input]: ", function["input"])
+
                             for var in function["input"]:
-                                print ("        var: ", var)
                                 index = var.rsplit('::', 1)[1]
-                            """
-                            index = [
-                                var.rsplit('::', 1)[1]
-                                for var in function["input"]
-                                if variable_name in var
-                            ][0]"""
+
                             function["updated"].append(
                                 f"@variable::{variable_name}::{int(index)+1}"
                             )
@@ -1970,7 +1956,6 @@ class GrFNGenerator(object):
                 }
             grfn["functions"].append(function)
 
-            print ("    Final GrFN: ", grfn, "\n")
         return [grfn]
 
     def process_compare(self, node, state, *_):
@@ -2234,8 +2219,6 @@ class GrFNGenerator(object):
                     "elem_type": array_type,
                     "mutable": True,
                 }
-                # DEBUG
-                print ("var_name: ", var_name)
                 self.arrays[var_name] = array_info
                 state.array_types[var_name] = array_type
 

--- a/tests/data/program_analysis/SIR-Gillespie-SD.f
+++ b/tests/data/program_analysis/SIR-Gillespie-SD.f
@@ -1,0 +1,139 @@
+C     Fortranification of AMIDOL's SIR-Gillespie.py
+********************************************************************************
+
+********************************************************************************
+      subroutine update_mean_var(MeanS, VarS, k, n, runs)
+      integer, parameter :: Tmax = 100
+      double precision, dimension(0:Tmax) :: MeanS, VarS
+      integer k, n, runs
+
+      MeanS(k) = MeanS(k) + (n - MeanS(k))/(runs+1)
+      VarS(k) = VarS(k) + runs/(runs+1) * (n-MeanS(k))*(n-MeanS(k))
+
+      return
+      end subroutine update_mean_var
+
+********************************************************************************
+C     Variables:
+C     beta     Rate of infection
+C     gamma    Rate of recovery from an infection
+C     rho      Basic reproduction Number
+C
+C     State Variables: S, I, R
+C     S - Susceptible population
+C     I - Infected population
+C     R - Recovered population
+C     n_S      current number of susceptible members
+C     n_I      current number of infected members
+C     n_R      current number of recovered members
+C     S0       initial value of S
+C     I0       initial value of I
+C     R0       initial value of R
+C     MeanS    Measures of Mean for S
+C     MeanI    Measures of Mean for I
+C     MeanR    Measures of Mean for R
+C     VarS     Measures of Variance for S
+C     VarI     Measures of Variance for I
+C     VarR     Measures of Variance for R
+C
+C     rateInfect    Current state dependent rate of infection
+C     rateRecover   Current state dependent rate of recovery
+C     totalRates    Sum of total rates; taking advantage of Markovian identities
+C                       to improve performance.
+C
+C     Tmax          Maximum time for the simulation
+C     t             Initial time for the simulation
+C     totalRuns     Total number of trajectories to generate for the analysis
+C     dt       next inter-event time
+********************************************************************************
+      subroutine gillespie(S0, I0, R0, MeanS, MeanI, MeanR, VarS, VarI,
+     &                     VarR)
+
+      integer, parameter :: Tmax = 100
+      integer S0, I0, R0
+      integer, parameter :: total_runs = 1000
+      double precision, parameter :: gamma = 1.0/3.0
+      double precision, parameter :: rho = 2.0
+      double precision, parameter :: beta = rho * gamma !
+
+      double precision, dimension(0:Tmax) :: MeanS, MeanI, MeanR
+      double precision, dimension(0:Tmax) :: VarS, VarI, VarR
+      integer, dimension(0:Tmax) :: samples
+
+      integer i, runs, n_S, n_I, n_R, sample_idx, sample
+      double precision rateInfect, rateRecover, totalRates, dt, t
+
+      do i = 0, Tmax    ! Initialize the mean and variance arrays
+         MeanS(i) = 0
+         MeanI(i) = 0.0
+         MeanR(i) = 0.0
+
+         VarS(i) = 0.0
+         VarI(i) = 0.0
+         VarR(i) = 0.0
+
+         samples(i) = i
+      end do
+
+      do runs = 0, total_runs-1
+         t = 0.0    ! Restart the event clock
+
+         n_S = S0
+         n_I = I0
+         n_R = R0
+
+         ! main Gillespie loop
+         sample_idx = 0
+         do while (t .le. Tmax .and. n_I .gt. 0)
+            rateInfect = beta * n_S * n_I / (n_S + n_I + n_R)
+            rateRecover = gamma * n_I
+            totalRates = rateInfect + rateRecover
+
+            dt = -log(1.0-rand())/totalRates  ! next inter-event time
+            t = t + dt          !  Advance the system clock
+
+            ! Calculate all measures up to the current time t using
+            ! Welford's one pass algorithm
+            do while (sample_idx < Tmax .and. t > samples(sample_idx))
+               sample = samples(sample_idx)
+               call update_mean_var(MeanS, VarS, sample, n_S, runs)
+               call update_mean_var(MeanI, VarI, sample, n_I, runs)
+               call update_mean_var(MeanR, VarR, sample, n_R, runs)
+               sample_idx = sample_idx+1
+            end do
+
+            ! Determine which event fired.  With probability rateInfect/totalRates
+            ! the next event is infection.
+            if (rand() < (rateInfect/totalRates)) then
+                ! Delta for infection
+                n_S = n_S - 1
+                n_I = n_I + 1
+            ! Determine the event fired.  With probability rateRecover/totalRates
+            ! the next event is recovery.
+            else
+                ! Delta for recovery
+                n_I = n_I - 1
+                n_R = n_R + 1
+            endif
+         end do
+
+         ! After all events have been processed, clean up by evaluating all remaining measures.
+         do while (sample_idx < Tmax)
+            sample = samples(sample_idx)
+            call update_mean_var(MeanS, VarS, sample, n_S, runs)
+            call update_mean_var(MeanI, VarI, sample, n_I, runs)
+            call update_mean_var(MeanR, VarR, sample, n_R, runs)
+            sample_idx = sample_idx + 1
+         end do
+      end do
+
+      end subroutine gillespie
+
+      program main
+      integer, parameter :: S0 = 500, I0 = 10, R0 = 0, Tmax = 100
+      double precision, dimension(0:Tmax) :: MeanS, MeanI, MeanR
+      double precision, dimension(0:Tmax) :: VarS, VarI, VarR
+
+      call gillespie(S0, I0, R0, MeanS, MeanI, MeanR, VarS, VarI, VarR)
+
+      end program main


### PR DESCRIPTION
This PR holds an additional bug fix in the `genPGM.py`.

A fix is for the error occurring when function calls happen with the mutable variable arguments passed as arguments. With this fix, now we are able to run `f2grfn` from end-to-end to generate GrFN (`SIR-Gillespie_SD_GrFN.json` and `SIR-Gillespie_SD_lambdas.py`) for the original `SIR-Gillespie_SD.f`.