### PR TITLE
Switching the ML4AI lab docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 
 env:
   global:
-    CACHE_IMAGE: pauldhein/project-containers
+    CACHE_IMAGE: ml4ailab/delphi
 
 before_install:
   - docker pull $CACHE_IMAGE:latest


### PR DESCRIPTION
Pretty simple, just switching where the docker image is hosted from my personal account to the lab account. @adarshp please merge.