### PR TITLE
Removing redundant git pull in Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
   - docker run $CI_ENV -itd --rm --name build-con $CACHE_IMAGE:latest
   - docker exec build-con git fetch
   - docker exec build-con git checkout $TRAVIS_BRANCH
-  - docker exec build-con git pull
 
 script:
   - docker exec build-con make test


### PR DESCRIPTION
So I added a redundant `git pull` command in the Travis testing file. This is not only unnecessary but it also causes builds from tag branches to fail. This PR removes that `git pull` command and should ensure that tests of tags pass in the future.