### PR TITLE
Cpp leak fix

### DIFF
--- a/apps/create_model.cpp
+++ b/apps/create_model.cpp
@@ -1,6 +1,7 @@
 // Usage: ./create_model <path_to_JSON_file>
 
 #include "AnalysisGraph.hpp"
+#include "rng.hpp"
 #include "spdlog/spdlog.h"
 #include <boost/program_options.hpp>
 
@@ -118,7 +119,7 @@ int main(int argc, char* argv[]) {
                                  vm["country"].as<string>());
   }
   if (vm["quantify"].as<bool>()) {
-    G.construct_beta_pdfs();
+    G.construct_beta_pdfs(RNG::rng()->get_RNG());
   }
 
   if (vm["draw_graph"].as<bool>() == true) {

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -1291,6 +1291,7 @@ AnalysisGraph::test_inference_with_synthetic_data(int start_year,
                                                   map<string, string> units,
                                                   InitialBeta initial_beta) {
   synthetic_data_experiment = true;
+  this->initialize_random_number_generator();
 
   this->n_timesteps = this->calculate_num_timesteps(
       start_year, start_month, end_year, end_month);
@@ -1323,6 +1324,7 @@ AnalysisGraph::test_inference_with_synthetic_data(int start_year,
       this->test_observed_state_sequence,
       this->generate_prediction(start_year, start_month, end_year, end_month));
 
+  RNG::release_instance();
   synthetic_data_experiment = false;
 }
 

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -27,6 +27,11 @@ const double tuning_param = 0.0001;
 
 typedef multimap<pair<int, int>, pair<int, int>>::iterator MMapIterator;
 
+void AnalysisGraph::set_random_seed(int seed) {
+  this->rng_instance = RNG::rng();
+  this->rng_instance->set_seed(seed);
+}
+
 size_t AnalysisGraph::num_vertices() {
   return boost::num_vertices(this->graph);
 }

--- a/lib/AnalysisGraph.cpp
+++ b/lib/AnalysisGraph.cpp
@@ -492,7 +492,7 @@ AnalysisGraph::from_causal_fragments(vector<CausalFragment> causal_fragments) {
       G.add_edge(cf);
     }
   }
-  G.initialize_random_number_generator();
+  //G.initialize_random_number_generator();
   return G;
 }
 

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -53,6 +53,7 @@ class AnalysisGraph {
 
   public:
   AnalysisGraph() {}
+  void set_random_seed(int seed);
   Node& operator[](std::string);
   Node& operator[](int);
   Edge& edge(EdgeDescriptor);
@@ -136,6 +137,7 @@ class AnalysisGraph {
   std::unordered_map<std::string, int> name_to_vertex = {};
 
   private:
+  RNG* rng_instance;
   void clear_state();
 
   // Keeps track of indicators in CAG to ensure there are no duplicates.

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -404,7 +404,7 @@ class AnalysisGraph {
                             2 * get_vertex_id(source_vertex_name) + 1);
   }
 
-  void construct_beta_pdfs();
+  void construct_beta_pdfs(std::mt19937 rng);
 
   AnalysisGraph
   find_all_paths_for_concept(std::string concept, int depth, bool reverse);

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -407,6 +407,7 @@ class AnalysisGraph {
   }
 
   void construct_beta_pdfs(std::mt19937 rng);
+  void construct_beta_pdfs();
 
   AnalysisGraph
   find_all_paths_for_concept(std::string concept, int depth, bool reverse);

--- a/lib/DelphiPython.cpp
+++ b/lib/DelphiPython.cpp
@@ -162,7 +162,8 @@ PYBIND11_MODULE(DelphiPython, m) {
            "indicator"_a)
       .def("set_derivative", &AnalysisGraph::set_derivative)
       .def("set_default_initial_state",
-           &AnalysisGraph::set_default_initial_state);
+           &AnalysisGraph::set_default_initial_state)
+      .def("set_random_seed", &AnalysisGraph::set_random_seed);
 
   py::class_<RV>(m, "RV")
       .def(py::init<std::string>())
@@ -191,11 +192,6 @@ PYBIND11_MODULE(DelphiPython, m) {
       .def("get_aggregation_method", &Indicator::get_aggregation_method)
       .def("get_timeseries", &Indicator::get_timeseries)
       .def("get_samples", &Indicator::get_samples);
-
-  py::class_<RNG>(m, "RNG")
-      .def_static("rng", &RNG::rng)
-      .def("set_seed", &RNG::set_seed, "seed"_a)
-      .def("get_seed", &RNG::get_seed);
 
   py::class_<Node>(m, "Node")
       .def_readwrite("name", &Node::name)

--- a/lib/DelphiPython.cpp
+++ b/lib/DelphiPython.cpp
@@ -3,6 +3,8 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+//#include <chrono>
+//#include <boost/random/mersenne_twister.hpp>
 
 #include "AnalysisGraph.hpp"
 
@@ -79,7 +81,9 @@ PYBIND11_MODULE(DelphiPython, m) {
            "label_depth"_a = 1,
            "node_to_highlight"_a = "",
            "rankdir"_a = "TB")
-      .def("construct_beta_pdfs", &AnalysisGraph::construct_beta_pdfs)
+      //.def("construct_beta_pdfs", &AnalysisGraph::construct_beta_pdfs)
+      //.def("construct_beta_pdfs", py::overload_cast<>(&AnalysisGraph::construct_beta_pdfs)
+      .def("construct_beta_pdfs", (void (AnalysisGraph::*)()) &AnalysisGraph::construct_beta_pdfs)
       .def("add_node", &AnalysisGraph::add_node, "concept"_a)
       .def("remove_node",
            py::overload_cast<string>(&AnalysisGraph::remove_node), "concept"_a)
@@ -210,7 +214,7 @@ PYBIND11_MODULE(DelphiPython, m) {
 
   py::class_<KDE>(m, "KDE")
       .def(py::init<vector<double>>())
-      .def("resample", &KDE::resample)
+      .def("resample", py::overload_cast<int>(&KDE::resample))
       .def("pdf",
            py::overload_cast<double>(&KDE::pdf),
            "Evaluate pdf for a single value")

--- a/lib/construct_beta_pdfs.cpp
+++ b/lib/construct_beta_pdfs.cpp
@@ -6,7 +6,7 @@ using namespace std;
 using namespace delphi::utils;
 
 AdjectiveResponseMap
-construct_adjective_response_map(size_t n_kernels = DEFAULT_N_SAMPLES) {
+construct_adjective_response_map(std::mt19937 rng, size_t n_kernels = DEFAULT_N_SAMPLES) {
   sqlite3* db = nullptr;
   int rc = sqlite3_open(getenv("DELPHI_DB"), &db);
 
@@ -32,7 +32,7 @@ construct_adjective_response_map(size_t n_kernels = DEFAULT_N_SAMPLES) {
   }
 
   for (auto& [k, v] : adjective_response_map) {
-    v = KDE(v).resample(n_kernels);
+    v = KDE(v).resample(rng, n_kernels);
   }
   sqlite3_finalize(stmt);
   sqlite3_close(db);
@@ -41,11 +41,11 @@ construct_adjective_response_map(size_t n_kernels = DEFAULT_N_SAMPLES) {
   return adjective_response_map;
 }
 
-void AnalysisGraph::construct_beta_pdfs() {
+void AnalysisGraph::construct_beta_pdfs(std::mt19937 rng) {
 
   double sigma_X = 1.0;
   double sigma_Y = 1.0;
-  AdjectiveResponseMap adjective_response_map = construct_adjective_response_map();
+  AdjectiveResponseMap adjective_response_map = construct_adjective_response_map(rng);
   vector<double> marginalized_responses;
   for (auto [adjective, responses] : adjective_response_map) {
     for (auto response : responses) {
@@ -54,7 +54,7 @@ void AnalysisGraph::construct_beta_pdfs() {
   }
 
   marginalized_responses =
-      KDE(marginalized_responses).resample(DEFAULT_N_SAMPLES);
+      KDE(marginalized_responses).resample(rng, DEFAULT_N_SAMPLES);
 
   for (auto e : this->edges()) {
     vector<double> all_thetas = {};

--- a/lib/construct_beta_pdfs.cpp
+++ b/lib/construct_beta_pdfs.cpp
@@ -7,13 +7,13 @@ using namespace delphi::utils;
 
 AdjectiveResponseMap
 construct_adjective_response_map(size_t n_kernels = DEFAULT_N_SAMPLES) {
-  sqlite3* db;
+  sqlite3* db = nullptr;
   int rc = sqlite3_open(getenv("DELPHI_DB"), &db);
 
   if (rc == 1)
     throw "Could not open db\n";
 
-  sqlite3_stmt* stmt;
+  sqlite3_stmt* stmt = nullptr;
   const char* query = "select * from gradableAdjectiveData";
   rc = sqlite3_prepare_v2(db, query, -1, &stmt, NULL);
 
@@ -36,6 +36,8 @@ construct_adjective_response_map(size_t n_kernels = DEFAULT_N_SAMPLES) {
   }
   sqlite3_finalize(stmt);
   sqlite3_close(db);
+  stmt = nullptr;
+  db = nullptr;
   return adjective_response_map;
 }
 

--- a/lib/construct_beta_pdfs.cpp
+++ b/lib/construct_beta_pdfs.cpp
@@ -32,7 +32,7 @@ construct_adjective_response_map(std::mt19937 rng, size_t n_kernels = DEFAULT_N_
   }
 
   for (auto& [k, v] : adjective_response_map) {
-    v = KDE(v).resample(rng, n_kernels);
+    v = KDE(v).resample(n_kernels, rng);
   }
   sqlite3_finalize(stmt);
   sqlite3_close(db);
@@ -54,7 +54,7 @@ void AnalysisGraph::construct_beta_pdfs(std::mt19937 rng) {
   }
 
   marginalized_responses =
-      KDE(marginalized_responses).resample(rng, DEFAULT_N_SAMPLES);
+      KDE(marginalized_responses).resample(DEFAULT_N_SAMPLES, rng);
 
   for (auto e : this->edges()) {
     vector<double> all_thetas = {};
@@ -85,5 +85,11 @@ void AnalysisGraph::construct_beta_pdfs(std::mt19937 rng) {
     // TODO: Decide the correct way to initialize this
     this->graph[e].beta = this->graph[e].kde.mu;
   }
+}
+
+void AnalysisGraph::construct_beta_pdfs() {
+  std::mt19937 rng = RNG::rng()->get_RNG();
+  this->construct_beta_pdfs(rng);
+  RNG::release_instance();
 }
 

--- a/lib/json_constructors.cpp
+++ b/lib/json_constructors.cpp
@@ -83,7 +83,6 @@ AnalysisGraph AnalysisGraph::from_json_file(string filename,
       }
     }
   }
-  //G.initialize_random_number_generator();
   return G;
 }
 
@@ -162,7 +161,6 @@ AnalysisGraph::from_uncharted_json_dict(nlohmann::json json_data) {
     string text = stmt["evidence"][0]["text"].get<string>();
     G.add_edge(causal_fragment);
   }
-  //G.initialize_random_number_generator();
   return G;
 }
 

--- a/lib/json_constructors.cpp
+++ b/lib/json_constructors.cpp
@@ -83,7 +83,7 @@ AnalysisGraph AnalysisGraph::from_json_file(string filename,
       }
     }
   }
-  G.initialize_random_number_generator();
+  //G.initialize_random_number_generator();
   return G;
 }
 
@@ -162,7 +162,7 @@ AnalysisGraph::from_uncharted_json_dict(nlohmann::json json_data) {
     string text = stmt["evidence"][0]["text"].get<string>();
     G.add_edge(causal_fragment);
   }
-  G.initialize_random_number_generator();
+  //G.initialize_random_number_generator();
   return G;
 }
 

--- a/lib/kde.cpp
+++ b/lib/kde.cpp
@@ -37,12 +37,19 @@ KDE::KDE(std::vector<double> v) : dataset(v) {
   bw = pow(4 * pow(stdev, 5) / (3 * N), 1 / 5);
 }
 
-vector<double> KDE::resample(std::mt19937 rng, int n_samples) {
+vector<double> KDE::resample(int n_samples, std::mt19937 rng) {
   vector<double> samples;
   for (int i : irange(0, n_samples)) {
     double element = select_random_element(rng, dataset);
     samples.push_back(sample_from_normal(rng, element, bw));
   }
+  return samples;
+}
+
+vector<double> KDE::resample(int n_samples) {
+  std::mt19937 rng = RNG::rng()->get_RNG();
+  vector<double> samples = this->resample(n_samples, rng);
+  RNG::release_instance();
   return samples;
 }
 

--- a/lib/kde.cpp
+++ b/lib/kde.cpp
@@ -15,14 +15,12 @@ using boost::lambda::_1;
 using namespace delphi::utils;
 
 double sample_from_normal(
-    std::mt19937 rng,
+    std::mt19937 gen,
     double mu = 0.0, /**< The mean of the distribution.*/
     double sd = 1.0  /**< The standard deviation of the distribution.*/
 ) {
-  //mt19937 gen = RNG::rng()->get_RNG();
   normal_distribution<> d{mu, sd};
-  //return d(gen);
-  return d(rng);
+  return d(gen);
 }
 
 KDE::KDE(std::vector<double> v) : dataset(v) {
@@ -37,18 +35,26 @@ KDE::KDE(std::vector<double> v) : dataset(v) {
   bw = pow(4 * pow(stdev, 5) / (3 * N), 1 / 5);
 }
 
-vector<double> KDE::resample(int n_samples, std::mt19937 rng) {
+vector<double> KDE::resample(int n_samples, std::mt19937 gen) {
   vector<double> samples;
   for (int i : irange(0, n_samples)) {
-    double element = select_random_element(rng, dataset);
-    samples.push_back(sample_from_normal(rng, element, bw));
+    double element = select_random_element(dataset, gen);
+    samples.push_back(sample_from_normal(gen, element, bw));
   }
   return samples;
 }
 
+/*
+ * TODO: Remove this method
+ * This method was introduced to make the old test code happy
+ * when the signature of resample() was updated to fix memory
+ * leaks.
+ * After updating the old test code, this method shoudl be
+ * removed from here and DelphiPython.cpp
+ */
 vector<double> KDE::resample(int n_samples) {
-  std::mt19937 rng = RNG::rng()->get_RNG();
-  vector<double> samples = this->resample(n_samples, rng);
+  std::mt19937 gen = RNG::rng()->get_RNG();
+  vector<double> samples = this->resample(n_samples, gen);
   RNG::release_instance();
   return samples;
 }

--- a/lib/kde.cpp
+++ b/lib/kde.cpp
@@ -15,12 +15,14 @@ using boost::lambda::_1;
 using namespace delphi::utils;
 
 double sample_from_normal(
+    std::mt19937 rng,
     double mu = 0.0, /**< The mean of the distribution.*/
     double sd = 1.0  /**< The standard deviation of the distribution.*/
 ) {
-  mt19937 gen = RNG::rng()->get_RNG();
+  //mt19937 gen = RNG::rng()->get_RNG();
   normal_distribution<> d{mu, sd};
-  return d(gen);
+  //return d(gen);
+  return d(rng);
 }
 
 KDE::KDE(std::vector<double> v) : dataset(v) {
@@ -35,11 +37,11 @@ KDE::KDE(std::vector<double> v) : dataset(v) {
   bw = pow(4 * pow(stdev, 5) / (3 * N), 1 / 5);
 }
 
-vector<double> KDE::resample(int n_samples) {
+vector<double> KDE::resample(std::mt19937 rng, int n_samples) {
   vector<double> samples;
   for (int i : irange(0, n_samples)) {
-    double element = select_random_element(dataset);
-    samples.push_back(sample_from_normal(element, bw));
+    double element = select_random_element(rng, dataset);
+    samples.push_back(sample_from_normal(rng, element, bw));
   }
   return samples;
 }

--- a/lib/kde.hpp
+++ b/lib/kde.hpp
@@ -5,6 +5,7 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 #include <boost/range/numeric.hpp>
+#include <chrono>
 
 /**
  * Returns a randomly selected element of a vector.
@@ -44,7 +45,8 @@ class KDE {
   // Not sure this is the correct way to do it.
   double mu;
 
-  std::vector<double> resample(std::mt19937 rng, int n_samples);
+  std::vector<double> resample(int n_samples, std::mt19937 rng = std::mt19937(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
+  std::vector<double> resample(int n_samples);
   double pdf(double x);
   std::vector<double> pdf(std::vector<double> v);
   double logpdf(double x);

--- a/lib/kde.hpp
+++ b/lib/kde.hpp
@@ -5,14 +5,12 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 #include <boost/range/numeric.hpp>
-#include <chrono>
 
 /**
  * Returns a randomly selected element of a vector.
  */
-template <class T> T select_random_element(std::mt19937 rng, std::vector<T> v) {
+template <class T> T select_random_element(std::vector<T> v, std::mt19937 gen) {
   using namespace std;
-  //mt19937 gen = RNG::rng()->get_RNG();
   T element;
   if (v.size() == 0) {
     throw "Vector is empty, so we cannot select a random element from it. "
@@ -23,8 +21,7 @@ template <class T> T select_random_element(std::mt19937 rng, std::vector<T> v) {
   }
   else {
     boost::random::uniform_int_distribution<> dist(0, v.size() - 1);
-    //element = v[dist(gen)];
-    element = v[dist(rng)];
+    element = v[dist(gen)];
   }
   return element;
 }
@@ -45,7 +42,7 @@ class KDE {
   // Not sure this is the correct way to do it.
   double mu;
 
-  std::vector<double> resample(int n_samples, std::mt19937 rng = std::mt19937(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
+  std::vector<double> resample(int n_samples, std::mt19937 rng);
   std::vector<double> resample(int n_samples);
   double pdf(double x);
   std::vector<double> pdf(std::vector<double> v);

--- a/lib/kde.hpp
+++ b/lib/kde.hpp
@@ -9,9 +9,9 @@
 /**
  * Returns a randomly selected element of a vector.
  */
-template <class T> T select_random_element(std::vector<T> v) {
+template <class T> T select_random_element(std::mt19937 rng, std::vector<T> v) {
   using namespace std;
-  mt19937 gen = RNG::rng()->get_RNG();
+  //mt19937 gen = RNG::rng()->get_RNG();
   T element;
   if (v.size() == 0) {
     throw "Vector is empty, so we cannot select a random element from it. "
@@ -22,7 +22,8 @@ template <class T> T select_random_element(std::vector<T> v) {
   }
   else {
     boost::random::uniform_int_distribution<> dist(0, v.size() - 1);
-    element = v[dist(gen)];
+    //element = v[dist(gen)];
+    element = v[dist(rng)];
   }
   return element;
 }
@@ -43,7 +44,7 @@ class KDE {
   // Not sure this is the correct way to do it.
   double mu;
 
-  std::vector<double> resample(int n_samples);
+  std::vector<double> resample(std::mt19937 rng, int n_samples);
   double pdf(double x);
   std::vector<double> pdf(std::vector<double> v);
   double logpdf(double x);

--- a/lib/rng.cpp
+++ b/lib/rng.cpp
@@ -1,5 +1,4 @@
 #include "rng.hpp"
-#include "dbg.h"
 
 RNG::RNG() {
     std::random_device rd;
@@ -13,7 +12,6 @@ int RNG::counter = 0;
 RNG *RNG::rng() {
   if (!m_pInstance)
     m_pInstance = new RNG;
-  dbg(counter);
 
   return m_pInstance;
 }
@@ -34,17 +32,14 @@ std::mt19937 RNG::get_RNG() {
 
 void RNG::add_ref() {
   ++counter;
-  dbg(counter);
 }
 
 void RNG::release_ref() {
   --counter;
-  dbg(counter);
 }
 
 void RNG::release_instance() {
   release_ref();
-  dbg(counter);
 
   if (counter == 0 && m_pInstance != NULL) {
     delete m_pInstance;

--- a/lib/rng.cpp
+++ b/lib/rng.cpp
@@ -1,4 +1,5 @@
 #include "rng.hpp"
+#include "dbg.h"
 
 RNG::RNG() {
     std::random_device rd;
@@ -7,10 +8,12 @@ RNG::RNG() {
 }
 
 RNG *RNG::m_pInstance = NULL;
+int RNG::counter = 0;
 
 RNG *RNG::rng() {
   if (!m_pInstance)
     m_pInstance = new RNG;
+  dbg(counter);
 
   return m_pInstance;
 }
@@ -22,4 +25,34 @@ void RNG::set_seed(int seed) {
 
 int RNG::get_seed() { return this->random_seed; }
 
-std::mt19937 RNG::get_RNG() { return this->gen; }
+std::mt19937 RNG::get_RNG() { 
+  /*
+  if (!m_pInstance) {
+    this->m_pInstance = new RNG();
+  }
+  */
+  // Track users
+  add_ref();
+
+  return this->gen;
+}
+
+void RNG::add_ref() {
+  ++counter;
+  dbg(counter);
+}
+
+void RNG::release_ref() {
+  --counter;
+  dbg(counter);
+}
+
+void RNG::release_instance() {
+  release_ref();
+  dbg(counter);
+
+  if (counter == 0 && m_pInstance != NULL) {
+    delete m_pInstance;
+    m_pInstance = NULL;
+  }
+}

--- a/lib/rng.cpp
+++ b/lib/rng.cpp
@@ -26,11 +26,6 @@ void RNG::set_seed(int seed) {
 int RNG::get_seed() { return this->random_seed; }
 
 std::mt19937 RNG::get_RNG() { 
-  /*
-  if (!m_pInstance) {
-    this->m_pInstance = new RNG();
-  }
-  */
   // Track users
   add_ref();
 

--- a/lib/rng.hpp
+++ b/lib/rng.hpp
@@ -12,7 +12,7 @@ public:
 
 private:
   RNG();
-  //~RNG(){};
+  ~RNG(){};
   RNG(RNG const &);
   RNG &operator=(RNG const &);
   static RNG *m_pInstance;

--- a/lib/rng.hpp
+++ b/lib/rng.hpp
@@ -8,12 +8,17 @@ public:
   void set_seed(int seed);
   int get_seed();
   std::mt19937 get_RNG();
+  static void release_instance();
 
 private:
   RNG();
+  //~RNG(){};
   RNG(RNG const &);
   RNG &operator=(RNG const &);
   static RNG *m_pInstance;
   int random_seed;
   std::mt19937 gen;
+  static void add_ref();
+  static void release_ref();
+  static int counter;
 };

--- a/lib/train_model.cpp
+++ b/lib/train_model.cpp
@@ -19,14 +19,14 @@ void AnalysisGraph::train_model(int start_year,
                                 InitialBeta initial_beta,
                                 bool use_heuristic) {
 
-  this->construct_beta_pdfs();
+  this->initialize_random_number_generator();
+  this->construct_beta_pdfs(this->rand_num_generator);
   this->find_all_paths();
   this->data_heuristic = use_heuristic;
 
   this->n_timesteps = this->calculate_num_timesteps(
       start_year, start_month, end_year, end_month);
   this->res = res;
-  this->initialize_random_number_generator();
   this->init_betas_to(initial_beta);
   this->sample_initial_transition_matrix_from_prior();
   this->parameterize(country, state, county, start_year, start_month, units);
@@ -75,5 +75,6 @@ void AnalysisGraph::train_model(int start_year,
   }
 
   this->trained = true;
+  RNG::release_instance();
   return;
 }

--- a/scripts/evaluations/oct_2019_eval.py
+++ b/scripts/evaluations/oct_2019_eval.py
@@ -1,5 +1,5 @@
 import delphi.evaluation as EN
-from delphi.cpp.DelphiPython import RNG, AnalysisGraph
+from delphi.cpp.DelphiPython import AnalysisGraph
 
 
 def create_base_CAG(uncharted_json_file):
@@ -75,9 +75,8 @@ def draw_CAG(G):
 
 
 if __name__ == "__main__":
-    r = RNG.rng()
-    r.set_seed(2018)
     G = create_base_CAG("data/Model4.json")
+    G.set_random_seed(2018)
     curate_indicators(G)
     G.data_heuristic = False
     G.parameterize("South Sudan", "Jonglei", "", 2017, 4, {})


### PR DESCRIPTION
Fixed memory leaks due to random number generator singleton class RNG.

Changed the signatures of AnalysisGraph::construct_beta_pdfs() and KDE::resample() methods. Had to overload those methods to retain their earlier signatures to make some old test code happy. Have to clean up that part of the test code and remove the old signatures.