### PR TITLE
Multiple module lambda fix

### DIFF
--- a/delphi/GrFN/networks.py
+++ b/delphi/GrFN/networks.py
@@ -432,27 +432,20 @@ class GroundedFunctionNetwork(ComputationalGraph):
         module_import_paths = {}
 
         """Builds GrFN object from Python source code."""
-        pgm_dict = f2grfn.generate_grfn(
-            pySrc,
-            python_file,
+        asts = [ast.parse(pySrc)]
+        pgm_dict = genPGM.create_grfn_dict(
             lambdas_path,
-            mode_mapper_dict[0],
-            str(fortran_file),
-            True,
+            asts,
+            python_file,
+            mode_mapper_dict,
+            fortran_file,
             module_log_file_path,
-            processing_modules
+            save_file,
+            module_file_exist,
+            module_import_paths
         )
 
-        filename_regex = re.compile(r"(?P<path>.*/)(?P<filename>.*).py")
-        file_match = re.match(filename_regex, python_file)
-        filename = file_match.group("filename")
-
-        lambdas = importlib.__import__(filename + "_lambdas")
-        # DEBUG
-        print ("    * python_file: ", python_file)
-        print ("    * stem: ", stem)
-        print ("    * lambdas: ", lambdas)
-        print ("    * lambdas_path: ", lambdas_path)
+        lambdas = importlib.__import__(stem + "_lambdas")
         return cls.from_dict(pgm_dict, lambdas)
 
     @classmethod

--- a/delphi/translators/for2py/f2grfn.py
+++ b/delphi/translators/for2py/f2grfn.py
@@ -660,10 +660,10 @@ def fortran_to_grfn(
     rectified_xml_file = temp_dir + "/" + "rectified_" + base + ".xml"
     pickle_file = temp_dir + "/" + base + "_pickle"
     variable_map_file = temp_dir + "/" + base + "_variables_pickle"
-    translated_python_files = [temp_dir + "/" + base + ".py"]
+    python_file = temp_dir + "/" + base + ".py"
     output_file = temp_dir + "/" + base + "_outputList.txt"
     json_file = temp_dir + "/" + base + ".json"
-    lambdas_file_path = temp_dir + "/" + base + "_lambdas.py"
+    # lambdas_file_path = temp_dir + "/" + base + "_lambdas.py"
 
     # Open and read original fortran file
     try:
@@ -698,7 +698,7 @@ def fortran_to_grfn(
     )
 
     # If a program uses module(s) that does not reside within the same file,
-    # we need to find out where the lives and process those files first. Thus,
+    # we need to find out where they live and process those files first. Thus,
     # the program should know the list of modules that require advance process
     # that was collected by rectify.py, below code will recursively call fortran_to_grfn
     # function to process module files end-to-end (Fortran-to-GrFN).
@@ -726,11 +726,13 @@ def fortran_to_grfn(
     output_dict = generate_outputdict(
         rectified_tree, preprocessed_fortran_file, pickle_file, tester_call
     )
+    translated_python_files = []
     # Create a python source file.
     python_source = generate_python_src(
         output_dict, translated_python_files, output_file, variable_map_file,
         temp_dir, tester_call
     )
+    translated_python_files.append(python_file)
     # Add generated list of files and log it for later removal, if needed.
     file_list = [output_file, pickle_file, variable_map_file]
     file_list.extend(translated_python_files)
@@ -749,12 +751,15 @@ def fortran_to_grfn(
             processing_modules,
         )
 
+    python_file_num = 0
     # Generate GrFN file
     for python_file in translated_python_files:
+        lambdas_file_path  = python_file[0:-3] + "_lambdas.py"
         grfn_dict = generate_grfn(
-            python_source[0][0], python_file, lambdas_file_path, mode_mapper_dict[0],
+            python_source[python_file_num][0], python_file, lambdas_file_path, mode_mapper_dict[0],
             original_fortran_file, False, module_log_file_path, processing_modules
         )
+        python_file_num += 1
 
 if __name__ == "__main__":
     fortran_to_grfn()

--- a/delphi/translators/for2py/f2grfn.py
+++ b/delphi/translators/for2py/f2grfn.py
@@ -207,7 +207,7 @@ def generate_outputdict(
 
 
 def generate_python_src(
-    output_dictionary, python_files,
+    output_dictionary, python_files, main_python_file,
     output_file, variable_map_file, temp_dir, tester_call
 ):
     """This function generates python source file from
@@ -250,9 +250,10 @@ def generate_python_src(
             module_file_generator(item, temp_dir, output_list, python_files)            
         else:
             try:
-                with open(python_files[0], "w") as f:
-                    output_list.append(python_files[0])
+                with open(main_python_file, "w") as f:
+                    output_list.append(main_python_file)
                     f.write(item[0])
+                python_files.append(main_python_file)
             except IOError:
                 assert False, f"Unable to write to {python_file_name}."
 
@@ -379,14 +380,14 @@ def generate_grfn(
     for item in grfn_dict["containers"]:
         if "gensym" in item:
             del item["gensym"]
-
     with open(mod_log_file_path) as json_f:
         module_logs = json.load(json_f)
     genPGM.generate_system_def(
             [python_filename],
             grfn_filepath_list,
             module_import_paths,
-            module_logs
+            module_logs,
+            original_fortran_file
     )
 
     log_generated_files([grfn_file, lambdas_file])
@@ -661,6 +662,7 @@ def fortran_to_grfn(
     pickle_file = temp_dir + "/" + base + "_pickle"
     variable_map_file = temp_dir + "/" + base + "_variables_pickle"
     python_file = temp_dir + "/" + base + ".py"
+
     output_file = temp_dir + "/" + base + "_outputList.txt"
     json_file = temp_dir + "/" + base + ".json"
     # lambdas_file_path = temp_dir + "/" + base + "_lambdas.py"
@@ -726,13 +728,13 @@ def fortran_to_grfn(
     output_dict = generate_outputdict(
         rectified_tree, preprocessed_fortran_file, pickle_file, tester_call
     )
+    
     translated_python_files = []
     # Create a python source file.
     python_source = generate_python_src(
-        output_dict, translated_python_files, output_file, variable_map_file,
-        temp_dir, tester_call
+        output_dict, translated_python_files, python_file, output_file,
+        variable_map_file, temp_dir, tester_call
     )
-    translated_python_files.append(python_file)
     # Add generated list of files and log it for later removal, if needed.
     file_list = [output_file, pickle_file, variable_map_file]
     file_list.extend(translated_python_files)

--- a/delphi/translators/for2py/f2grfn.py
+++ b/delphi/translators/for2py/f2grfn.py
@@ -662,10 +662,9 @@ def fortran_to_grfn(
     pickle_file = temp_dir + "/" + base + "_pickle"
     variable_map_file = temp_dir + "/" + base + "_variables_pickle"
     python_file = temp_dir + "/" + base + ".py"
-
     output_file = temp_dir + "/" + base + "_outputList.txt"
     json_file = temp_dir + "/" + base + ".json"
-    # lambdas_file_path = temp_dir + "/" + base + "_lambdas.py"
+    lambdas_file_suffix = "_lambdas.py"
 
     # Open and read original fortran file
     try:
@@ -743,7 +742,6 @@ def fortran_to_grfn(
     if tester_call:
         return (
             python_source,
-            lambdas_file_path,
             json_file,
             translated_python_files,
             base,
@@ -756,7 +754,7 @@ def fortran_to_grfn(
     python_file_num = 0
     # Generate GrFN file
     for python_file in translated_python_files:
-        lambdas_file_path  = python_file[0:-3] + "_lambdas.py"
+        lambdas_file_path  = python_file[0:-3] + lambdas_file_suffix
         grfn_dict = generate_grfn(
             python_source[python_file_num][0], python_file, lambdas_file_path, mode_mapper_dict[0],
             original_fortran_file, False, module_log_file_path, processing_modules

--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -3958,7 +3958,8 @@ def generate_system_def(
         python_list: List[str],
         module_grfn_list: List[str],
         import_grfn_paths: List[str],
-        module_logs: Dict
+        module_logs: Dict,
+        original_file_path: str,
 ):
     """
         This function generates the system definition for the system under
@@ -3977,6 +3978,9 @@ def generate_system_def(
             if module_name in module_logs["mod_to_file"]:
                 for path in module_logs["mod_to_file"][module_name]:
                     code_sources.append(path)
+
+        if not code_sources:
+            code_sources.append(original_file_path)
         grfn_components.append({
             "grfn_source": module_grfn,
             "code_source": code_sources,

--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -132,6 +132,7 @@ class GrFNGenerator(object):
         self.module_subprograms = []
         # Holds module names
         self.module_names = []
+        self.generated_lambda_functions = []
 
         self.gensym_tag_map = {
             "container": 'c',
@@ -2074,7 +2075,10 @@ class GrFNGenerator(object):
                     argument_list
                 )
 
-                if need_lambdas:
+                if (
+                        need_lambdas
+                        and container_id_name not in self.generated_lambda_functions
+                ):
                     lambda_string = self.generate_lambda_function(
                         node,
                         container_id_name,
@@ -3032,6 +3036,7 @@ class GrFNGenerator(object):
                                  return_value: bool, array_assign: bool,
                                  string_assign: bool, inputs, state,
                                  is_custom: bool):
+        self.generated_lambda_functions.append(function_name)
         lambda_for_var = True
         lambda_strings = []
         argument_strings = []

--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -1985,14 +1985,13 @@ class GrFNGenerator(object):
                             node, function, arg,
                             function_name, container_id_name,
                             arr_index, state)
+                        generate_lambda_for_arr = True
                     # This is a case where a literal gets assigned to an array.
                     # For example, arr(i) = 100.
                     elif "type" in arg[0] and array_set:
                         generate_lambda_for_arr = True
 
-                    if (
-                            generate_lambda_for_arr
-                    ):
+                    if generate_lambda_for_arr:
                         lambda_string = self.generate_lambda_function(
                             node,
                             container_id_name,
@@ -2028,6 +2027,7 @@ class GrFNGenerator(object):
             # Below is a separate loop just for filling in inputs for arrays
             if array_set:
                 argument_list = []
+                need_lambdas = False
                 for arg in call["inputs"]:
                     for ip in arg:
                         if 'var' in ip:
@@ -2040,6 +2040,7 @@ class GrFNGenerator(object):
                         elif 'call' in ip:
                             function_call = ip['call']
                             function_name = function_call['function']
+                            need_lambdas = True
                             if '.get_' in function_name:
                                 function_name = function_name.replace(
                                     ".get_", "")
@@ -2073,17 +2074,19 @@ class GrFNGenerator(object):
                     argument_list
                 )
 
-                lambda_string = self.generate_lambda_function(
-                    node,
-                    container_id_name,
-                    True,
-                    True,
-                    False,
-                    argument_list,
-                    state,
-                    False
-                )
-                state.lambda_strings.append(lambda_string)
+                if need_lambdas:
+                    lambda_string = self.generate_lambda_function(
+                        node,
+                        container_id_name,
+                        True,
+                        True,
+                        False,
+                        argument_list,
+                        state,
+                        False
+                    )
+                    state.lambda_strings.append(lambda_string)
+                    need_lambdas = False
 
             # Make an assign function for a string .set_ operation
             if string_set:

--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -1990,7 +1990,9 @@ class GrFNGenerator(object):
                     elif "type" in arg[0] and array_set:
                         generate_lambda_for_arr = True
 
-                    if generate_lambda_for_arr:
+                    if (
+                            generate_lambda_for_arr
+                    ):
                         lambda_string = self.generate_lambda_function(
                             node,
                             container_id_name,
@@ -2025,6 +2027,7 @@ class GrFNGenerator(object):
 
             # Below is a separate loop just for filling in inputs for arrays
             if array_set:
+                argument_list = []
                 for arg in call["inputs"]:
                     for ip in arg:
                         if 'var' in ip:
@@ -2032,6 +2035,8 @@ class GrFNGenerator(object):
                                 f"@variable::"
                                 f"{ip['var']['variable']}::"
                                 f"{ip['var']['index']}")
+                            if ip['var']['variable'] not in argument_list:
+                                argument_list.append(ip['var']['variable'])
                         elif 'call' in ip:
                             function_call = ip['call']
                             function_name = function_call['function']
@@ -2047,6 +2052,8 @@ class GrFNGenerator(object):
                                         f"@variable::"
                                         f"{function_name}::"
                                         f"{state.last_definitions[function_name]}")
+                                if function_name not in argument_list:
+                                    argument_list.append(function_name)
                             for call_input in function_call['inputs']:
                                 # TODO: This is of a recursive nature. Make
                                 #  this a loop. Works for SIR for now.
@@ -2056,10 +2063,27 @@ class GrFNGenerator(object):
                                             f"@variable::"
                                             f"{var['var']['variable']}::"
                                             f"{var['var']['index']}")
+                                        if var['var']['variable'] not in argument_list:
+                                            argument_list.append(var['var']['variable'])
 
                 function["input"] = self._remove_duplicate_from_list(
                     function["input"]
                 )
+                argument_list = self._remove_duplicate_from_list(
+                    argument_list
+                )
+
+                lambda_string = self.generate_lambda_function(
+                    node,
+                    container_id_name,
+                    True,
+                    True,
+                    False,
+                    argument_list,
+                    state,
+                    False
+                )
+                state.lambda_strings.append(lambda_string)
 
             # Make an assign function for a string .set_ operation
             if string_set:

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -2602,8 +2602,6 @@ class RectifyOFPXML:
         mod_to_file_mapper = module_logs["mod_to_file"]
         
         use_module = root.attrib['name']
-        # DEBUG
-        print ("    * mod_to_file_mapper: ", mod_to_file_mapper)
         if use_module.lower() in mod_to_file_mapper:
             use_module_file_path = mod_to_file_mapper[use_module.lower()]
             if (

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -2602,15 +2602,20 @@ class RectifyOFPXML:
         mod_to_file_mapper = module_logs["mod_to_file"]
         
         use_module = root.attrib['name']
-        use_module_file_path = mod_to_file_mapper[use_module.lower()]
-        if (
-                use_module_file_path[0] != self.original_fortran_file_abs_path
-                and use_module not in self.modules_in_file
-        ):
-            self.module_files_to_process.append(use_module_file_path[0])
+        # DEBUG
+        print ("    * mod_to_file_mapper: ", mod_to_file_mapper)
+        if use_module.lower() in mod_to_file_mapper:
+            use_module_file_path = mod_to_file_mapper[use_module.lower()]
+            if (
+                    use_module_file_path[0] != self.original_fortran_file_abs_path
+                    and use_module not in self.modules_in_file
+            ):
+                self.module_files_to_process.append(use_module_file_path[0])
+            else:
+                # If module resides in the same file, we don't have to do anything.
+                # Handling for this case is alreadyd implemented in genPGM.py
+                pass
         else:
-            # If module resides in the same file, we don't have to do anything.
-            # Handling for this case is alreadyd implemented in genPGM.py
             pass
 
         for child in root:

--- a/tests/aske/test_GrFN.py
+++ b/tests/aske/test_GrFN.py
@@ -39,11 +39,6 @@ def sir_gillespie_inline_grfn():
 
 
 @pytest.fixture
-def gillespie_mult_grfn():
-    return GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/SIR-Gillespie-SD_multi_module.f")
-
-
-@pytest.fixture
 def sir_gillespie_ms_grfn():
     return GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/SIR-Gillespie-MS.f")
 
@@ -117,14 +112,6 @@ def test_sir_gillespie_inline_creation(sir_gillespie_inline_grfn):
     G.draw('SIR-Gillespie_inline--GrFN.pdf', prog='dot')
     CAG = sir_gillespie_inline_grfn.to_CAG_agraph()
     CAG.draw('SIR-Gillespie_inline--CAG.pdf', prog='dot')
-
-
-def test_mult_files_grfn(gillespie_mult_grfn):
-    assert isinstance(gillespie_mult_grfn, GroundedFunctionNetwork)
-    G = gillespie_mult_grfn.to_agraph()
-    G.draw('SIR-Gillespie_multi--GrFN.pdf', prog='dot')
-    CAG = gillespie_mult_grfn.to_CAG_agraph()
-    CAG.draw('SIR-Gillespie_multi--CAG.pdf', prog='dot')
 
 
 def test_sir_gillespie_ms_creation(sir_gillespie_ms_grfn):

--- a/tests/aske/test_GrFN.py
+++ b/tests/aske/test_GrFN.py
@@ -39,6 +39,11 @@ def sir_gillespie_inline_grfn():
 
 
 @pytest.fixture
+def gillespie_mult_grfn():
+    return GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/SIR-Gillespie-SD_multi_module.f")
+
+
+@pytest.fixture
 def sir_gillespie_ms_grfn():
     return GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/SIR-Gillespie-MS.f")
 
@@ -112,6 +117,14 @@ def test_sir_gillespie_inline_creation(sir_gillespie_inline_grfn):
     G.draw('SIR-Gillespie_inline--GrFN.pdf', prog='dot')
     CAG = sir_gillespie_inline_grfn.to_CAG_agraph()
     CAG.draw('SIR-Gillespie_inline--CAG.pdf', prog='dot')
+
+
+def test_mult_files_grfn(gillespie_mult_grfn):
+    assert isinstance(gillespie_mult_grfn, GroundedFunctionNetwork)
+    G = gillespie_mult_grfn.to_agraph()
+    G.draw('SIR-Gillespie_multi--GrFN.pdf', prog='dot')
+    CAG = gillespie_mult_grfn.to_CAG_agraph()
+    CAG.draw('SIR-Gillespie_multi--CAG.pdf', prog='dot')
 
 
 def test_sir_gillespie_ms_creation(sir_gillespie_ms_grfn):

--- a/tests/aske/test_program_analysis.py
+++ b/tests/aske/test_program_analysis.py
@@ -32,9 +32,10 @@ def get_python_source(
 
 
 def make_grfn_dict(original_fortran_file) -> Dict:
+    lambda_file_suffix = "_lambdas.py"
+
     (
         pySrc, 
-        lambdas_filename,
         json_filename, 
         python_filenames,
         base, 
@@ -45,6 +46,7 @@ def make_grfn_dict(original_fortran_file) -> Dict:
     ) = get_python_source(original_fortran_file)
 
     for python_file in python_filenames:
+        lambdas_filename  = python_file[0:-3] + lambda_file_suffix
         _dict = f2grfn.generate_grfn(
             pySrc[0][0],
             python_file,
@@ -297,7 +299,7 @@ def test_multidimensional_array_grfn_generation(multidimensional_array_test):
     assert str(multidimensional_array_test) == grfn_dict
 
 
-def test_sri_gillespie_sd_grfn_generation(sir_gillespie_sd_test):
+def test_sir_gillespie_sd_grfn_generation(sir_gillespie_sd_test):
     with open(f"{DATA_DIR}/SIR-Gillespie-SD_multi_module_GrFN.json", "r") as f:
         grfn_dict = f.read()
     assert str(sir_gillespie_sd_test) == grfn_dict


### PR DESCRIPTION
This PR holds fixes for bugs occurred during generating lambda files for
single source file with multiple modules. The reason for the bug was
conflicting code between handling multiple source files vs. single file multiple modules.
Code for distinguishing these two cases are added.