### PR TITLE
Concept to indicator mapping update

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -178,7 +178,7 @@ EIDOS_SRC := $(EIDOS)/src/main
 ONTOLOGY_GEN_SCRIPT := $(EIDOS_SRC)/python/mk_yaml_ontology.py
 
 TARGET_ONTOLOGY_FILENAME := $(EIDOS_SRC)/resources/org/clulab/wm/eidos/english/ontologies/delphi_db_indicators.yml
-TARGET_ONTOLOGY_NAME := MITRE12
+TARGET_ONTOLOGY_NAME := delphi_db_indicators
 
 SCALA_VERSION:=2.12
 EIDOS_VERSION:=0.2.3

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -177,7 +177,7 @@ EIDOS_SRC := $(EIDOS)/src/main
 # from our data tables.
 ONTOLOGY_GEN_SCRIPT := $(EIDOS_SRC)/python/mk_yaml_ontology.py
 
-TARGET_ONTOLOGY_FILENAME := $(EIDOS_SRC)/resources/org/clulab/wm/eidos/english/ontologies/mitre12_indicators.yml
+TARGET_ONTOLOGY_FILENAME := $(EIDOS_SRC)/resources/org/clulab/wm/eidos/english/ontologies/delphi_db_indicators.yml
 TARGET_ONTOLOGY_NAME := MITRE12
 
 SCALA_VERSION:=2.12
@@ -191,7 +191,7 @@ $(WORD_EMBEDDING_VECTORS):
 EIDOS_JAR:=target/scala-$(SCALA_VERSION)/eidos-assembly-$(EIDOS_VERSION)-SNAPSHOT.jar
 
 $(EIDOS)/$(EIDOS_JAR):
-	cd $(EIDOS); JAVA_OPTS=-Xmx16g time sbt assembly 
+	cd $(EIDOS); JAVA_OPTS=-Xmx50g time sbt assembly
 
 data/primary_to_indicators.tsv: data/indicator_flat_list.txt\
 						   $(ONTOLOGY_GEN_SCRIPT)\

--- a/scripts/create_delphi_db.py
+++ b/scripts/create_delphi_db.py
@@ -59,7 +59,7 @@ def create_concept_to_indicator_mapping_table(mapping_table):
         sep='\t',
     )
     df.Indicator = df.Indicator.str.replace("\\\/", "/")
-    df = df[df["Source"] == "mitre12"]
+    df = df[df["Source"] == "delphi_db_inds"]
     df.Indicator = df.Indicator.str.replace("MITRE12/", "")
 
     insert_table(df, "concept_to_indicator_mapping")

--- a/scripts/create_delphi_db.py
+++ b/scripts/create_delphi_db.py
@@ -59,8 +59,9 @@ def create_concept_to_indicator_mapping_table(mapping_table):
         sep='\t',
     )
     df.Indicator = df.Indicator.str.replace("\\\/", "/")
-    df = df[df["Source"] == "delphi_db_inds"]
-    df.Indicator = df.Indicator.str.replace("MITRE12/", "")
+    df.Indicator = df.Indicator.str.replace("_", " ")
+    df = df[df["Source"] == "delphi_db_indicators"]
+    df.Indicator = df.Indicator.str.replace(" delphi_db_indicators/", "")
 
     insert_table(df, "concept_to_indicator_mapping")
 

--- a/scripts/data_processing/combine_data.py
+++ b/scripts/data_processing/combine_data.py
@@ -110,12 +110,12 @@ def combine_data(outputFile):
         "data/World-Bank-data.csv", index_col=False, dtype=dtype_dict
     )
 
-    dssat_oct2019_eval_data_df = read_csv('data/dssat_data_oct2019_eval.tsv')
-    
+    dssat_oct2019_eval_data_df = read_csv("data/dssat_data_oct2019_eval.tsv")
+
     IOM_DTM1_df = pd.read_csv(
         "data/IOM-DTM-data1.csv", index_col=False, dtype=dtype_dict
     )
-    
+
     combined_df = pd.concat(
         [
             fao_wdi_df,


### PR DESCRIPTION
This PR updates the concept to indicator mapping scripts for a more recent version of Eidos, with the WM ontology, etc.

The `eidos.conf` that this was tested with is given below:

```scala
EidosSystem {
// Override the default values here
             language = english
      masterRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/master.yml
         taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
          hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
        entityFinders = ["gazetteer", "rulebased", "geonorm", "timenorm"]
 keepStatefulConcepts = true
             cacheDir = ./cache
}

filtering {
  stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
  transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
}

actions {
  useCoref = true
  corefType = "causalBasic"
  taxonomyPath = ${EidosSystem.taxonomyPath}
  useExpansion = true
}

apps {
  inputDirectory = "."
  outputDirectory = "."
  inputFileExtension = ".txt"
  exportAs = ["serialized", "jsonld", "mitre"] // valid modes: jsonld, mitre, serialized
  groundAs = ["wm", "delphi_db_indicators"]//, "interventions"] // make sure these match ontologies below
  groundTopN = 10
  ontologymapper {
    outfile = src/main/resources/org/clulab/wm/eidos/english/ontologies/primary_to_indicators.tsv
  }
}

ontologies {
  // W2V
  useW2V = true
  wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.txt

  // Activated Ontologies
  ontologies = ["wm", "delphi_db_indicators"]//, "interventions"] // , "icasa", "mesh"]

  // Caching, for quick loading, language dependent
  cacheDir = ${EidosSystem.cacheDir}/${EidosSystem.language}
  useCache = false
  includeParents = true

  // Primary
  // Note that this first one is included via build.sbt.  It is not directly part of eidos.
  wm             = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/wm_metadata.yml

  // Indicators
  delphi_db_indicators = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/delphi_db_indicators.yml
}

geonorm {
  geoNamesIndexURL      = "http://clulab.cs.arizona.edu/models/geonames+woredas.zip"
  geoNamesIndexPath     = ${EidosSystem.cacheDir}/geonames/index
}

timenorm {
  timeRegexPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/timenorm-regexes.txt
}

adjectiveGrounder {
  domainParamKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/domain_parameters.kb
   quantifierKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/gradable_adj_fullmodel.kb
}
```