### PR TITLE
Additional derived type array cases.

### DIFF
--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -2932,28 +2932,67 @@ class GrFNGenerator(object):
                 dimension_info = attrib.value.args[1]
                 is_literal = False
                 is_name = False
-                lower_bound = int(dimension_info.elts[0].elts[0].n)
+                
+                single_dimension = False
+                dimension_list = []
+                if isinstance(dimension_info.elts[0], ast.Tuple):
+                    lower_bound = int(dimension_info.elts[0].elts[0].n)
+                    single_dimension = True
 
-                # Retrieve upper bound of an array.
-                if isinstance(dimension_info.elts[0].elts[1], ast.Num):
-                    upper_bound = int(dimension_info.elts[0].elts[1].n)
-                    is_literal = True
-                elif isinstance(dimension_info.elts[0].elts[1], ast.Name):
-                    upper_bound = dimension_info.elts[0].elts[1].id
-                    is_name = True
-                else:
-                    assert (
-                            False
-                    ), f"Currently, ast type [{type(dimension_info.elts[0].elts[1])}] is not supported."
+                    # Retrieve upper bound of an array.
+                    if isinstance(dimension_info.elts[0].elts[1], ast.Num):
+                        upper_bound = int(dimension_info.elts[0].elts[1].n)
+                        is_literal = True
+                    elif isinstance(dimension_info.elts[0].elts[1], ast.Name):
+                        upper_bound = dimension_info.elts[0].elts[1].id
+                        is_name = True
+                    else:
+                        assert (
+                                False
+                        ), f"Currently, ast type [{type(dimension_info.elts[0].elts[1])}] is not supported."
 
-                if is_literal:
-                    dimension = (upper_bound - lower_bound) + 1
-                elif is_name:
-                    dimension = upper_bound
-                else:
-                    pass
+                    if is_literal:
+                        dimension = (upper_bound - lower_bound) + 1
+                    elif is_name:
+                        dimension = upper_bound
+                    else:
+                        pass
 
-                dimensions = [dimension]
+                    dimension_list.append(dimension)
+
+                elif isinstance(dimension_info.elts[0], ast.Call):
+                    lower_bound = int(dimension_info.elts[0].func.elts[0].n)
+                    if isinstance(dimension_info.elts[0].func.elts[1], ast.Num):
+                        upper_bound = int(dimension_info.elts[0].func.elts[1].n)
+                        is_literal = True
+                    elif isinstance(dimension_info.elts[0].func.elts[1], ast.Name):
+                        upper_bound = dimension_info.elts[0].func.elts[1].id
+                        is_name = True
+
+                    if is_literal:
+                        first_dimension = (upper_bound - lower_bound) + 1
+                    elif is_name:
+                        first_dimension = upper_bound
+
+                    dimension_list.append(first_dimension)
+
+                    lower_bound = int(dimension_info.elts[0].args[0].n)
+
+                    if isinstance(dimension_info.elts[0].args[1], ast.Num):
+                        upper_bound = int(dimension_info.elts[0].args[1].n)
+                        is_literal = True
+                    elif isinstance(dimension_info.elts[0].args[1], ast.Name):
+                        upper_bound = dimension_info.elts[0].args[1].id
+                        is_name = True
+
+                    if is_literal:
+                        second_dimension = (upper_bound - lower_bound) + 1
+                    elif is_name:
+                        second_dimension = upper_bound
+
+                    dimension_list.append(second_dimension)
+
+                dimensions = dimension_list
 
                 grfn["attributes"].append({
                                             "name": attrib_name,

--- a/delphi/translators/for2py/genPGM.py
+++ b/delphi/translators/for2py/genPGM.py
@@ -2930,9 +2930,29 @@ class GrFNGenerator(object):
                 # appropriate to handle a multi-dimensional with variable used
                 # as a dimension size.
                 dimension_info = attrib.value.args[1]
+                is_literal = False
+                is_name = False
                 lower_bound = int(dimension_info.elts[0].elts[0].n)
-                upper_bound = int(dimension_info.elts[0].elts[1].n)
-                dimension = (upper_bound - lower_bound) + 1
+
+                # Retrieve upper bound of an array.
+                if isinstance(dimension_info.elts[0].elts[1], ast.Num):
+                    upper_bound = int(dimension_info.elts[0].elts[1].n)
+                    is_literal = True
+                elif isinstance(dimension_info.elts[0].elts[1], ast.Name):
+                    upper_bound = dimension_info.elts[0].elts[1].id
+                    is_name = True
+                else:
+                    assert (
+                            False
+                    ), f"Currently, ast type [{type(dimension_info.elts[0].elts[1])}] is not supported."
+
+                if is_literal:
+                    dimension = (upper_bound - lower_bound) + 1
+                elif is_name:
+                    dimension = upper_bound
+                else:
+                    pass
+
                 dimensions = [dimension]
 
                 grfn["attributes"].append({

--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -501,16 +501,16 @@ class PythonCodeGenerator(object):
             is_derived_type_ref = True
         else:
             ref_str = self.nameMapper[node["name"]]
-
         # If the variable is a saved variable, prefix it by the function name
         # to access the saved value of the variable
-        if is_derived_type_ref:
-            if ref_str.split('.')[0] in \
-                        self.saved_variables[self.current_module]:
-                ref_str = f"{self.current_module}.{ref_str}"
-        else:
-            if ref_str in self.saved_variables[self.current_module]:
-                ref_str = f"{self.current_module}.{ref_str}"
+        if self.current_module in self.saved_variables:
+            if is_derived_type_ref:
+                if ref_str.split('.')[0] in \
+                            self.saved_variables[self.current_module]:
+                    ref_str = f"{self.current_module}.{ref_str}"
+            else:
+                if ref_str in self.saved_variables[self.current_module]:
+                    ref_str = f"{self.current_module}.{ref_str}"
 
         if "subscripts" in node:
             # array reference or function call or string indexing

--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -1552,6 +1552,10 @@ class PythonCodeGenerator(object):
                     "range" in dimension
             ):  # A case where explicit low and up bounds are set
                 array_range += f"({self.get_range(dimension['range'][0])})"
+            elif (
+                    "name" in dimension
+            ): # A case where variable name given as a size with no explicit lower bound.
+                array_range += f"(0, {dimension['name']})"
             else:
                 assert (
                     False

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -405,6 +405,12 @@ class RectifyOFPXML:
         "parameter-stmt",
         "type-param-value",
         "char-selector",
+        "component-attr-spec-list__begin",
+        "explicit-shape-spec-list__begin",
+        "explicit-shape-spec",
+        "explicit-shape-spec-list",
+        "component-attr-spec",
+        "component-attr-spec-list",
     ]
 
     output_child_tags = [
@@ -965,6 +971,7 @@ class RectifyOFPXML:
             elif (
                     child.tag == "component-decl"
                     or child.tag == "component-decl-list"
+                    or child.tag == "name"
             ):
                 self.derived_type_var_holder_list.append(child)
             elif child.tag == "length":

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -807,8 +807,6 @@ class RectifyOFPXML:
             if child.tag == "component-attr-spec-list__begin":
                 is_derived_type_handling = True
             if len(child) > 0 or child.text:
-                # DEBUG
-                print ("    tag_declaration - child: ", child)
                 if child.tag in self.declaration_child_tags:
                     if child.tag == "format":
                         self.is_format = True
@@ -2984,8 +2982,6 @@ class RectifyOFPXML:
             # declarations will follow.
             derived_type = ET.SubElement(self.parent_type, "derived-types")
             for elem in self.derived_type_var_holder_list:
-                # DEBUG
-                print ("    * elem: ", elem)
                 if elem.tag == "intrinsic-type-spec":
                     keyword2 = ""
                     if elem.attrib['keyword2'] == "":

--- a/delphi/translators/for2py/translate.py
+++ b/delphi/translators/for2py/translate.py
@@ -545,11 +545,15 @@ class XML_to_JSON_translator(object):
             elif node.tag == "dimensions":
                 dimensions = {
                     "count": node.attrib["count"],
-                    "dimensions": [{"tag": "dimension"}],
+                    "dimensions": [],
                 }
-                dimensions["dimensions"][0].update(
-                    self.parseTree(node, state)[-1]
-                )
+                dims = self.parseTree(node, state)
+                for dim in dims:
+                    dim_info = {
+                            "tag": "dimension",
+                            "range": dim["range"]
+                    }
+                    dimensions["dimensions"].append(dim_info)
                 declared_type[-1].update(dimensions)
             elif node.tag == "variables":
                 variables = self.parseTree(node, state)
@@ -763,7 +767,6 @@ class XML_to_JSON_translator(object):
                 "is_arg": "false",
                 "is_parameter": "false",
             }
-
             # Check whether the passed element is for derived type reference
             if "is_derived_type_ref" in root.attrib:
                 ref["is_derived_type_ref"] = "true"

--- a/delphi/translators/for2py/translate.py
+++ b/delphi/translators/for2py/translate.py
@@ -850,12 +850,16 @@ class XML_to_JSON_translator(object):
             root.tag == "dimension"
         ), f"The root must be <dimension>. Current tag is {root.tag} with " \
             f"{root.attrib} attributes."
-        dimension = {"tag": "dimension"}
+        dimension = {}
         for node in root:
             if node.tag == "range":
                 dimension["range"] = self.parseTree(node, state)
             if node.tag == "literal":
                 dimension["literal"] = self.parseTree(node, state)
+            if node.tag == "name":
+                dimension_info = self.parseTree(node, state)
+                dimension = dimension_info[0]
+        dimension["tag"] = "dimension"
         return [dimension]
 
     def process_range(self, root, state) -> List[Dict]:

--- a/tests/aske/test_program_analysis.py
+++ b/tests/aske/test_program_analysis.py
@@ -202,6 +202,10 @@ def derived_type_grfn_test():
     yield make_grfn_dict(Path(f"{DATA_DIR}/derived-types/derived-types-04.f"))
 
 
+@pytest.fixture
+def derived_type_array_grfn_test():
+    yield make_grfn_dict(Path(f"{DATA_DIR}/derived-types/derived-types-02.f"))
+
 #########################################################
 #                                                       #
 #                   PYTHON IR TEST                      #
@@ -364,3 +368,16 @@ def test_derived_type_grfn_generation(derived_type_grfn_test):
     assert str(target_lambda_functions) == str(generated_lamdba_functions)
 
     f2grfn.cleanup_files(derived_type_grfn_test[2])
+
+def test_derived_type_array_grfn_generation(derived_type_array_grfn_test):
+    with open(f"{DATA_DIR}/derived-types/derived-types-02_GrFN.json", "r") as f:
+        grfn_dict = f.read()
+    assert str(derived_type_array_grfn_test[0]) == grfn_dict
+
+    with open(f"{DATA_DIR}/derived-types/derived-types-02_lambdas.py", "r") as f:
+        target_lambda_functions = f.read()
+    with open(f"{TEMP_DIR}/{derived_type_array_grfn_test[1]}", "r") as l:
+        generated_lamdba_functions = l.read()
+    assert str(target_lambda_functions) == str(generated_lamdba_functions)
+
+    f2grfn.cleanup_files(derived_type_array_grfn_test[2])

--- a/tests/data/program_analysis/derived-types/derived-types-02.f
+++ b/tests/data/program_analysis/derived-types/derived-types-02.f
@@ -41,4 +41,3 @@ C  3   6.000   2.000   2.500   3.000
 
       stop
       end program main
-

--- a/tests/data/program_analysis/derived-types/derived-types-02_GrFN.json
+++ b/tests/data/program_analysis/derived-types/derived-types-02_GrFN.json
@@ -1,0 +1,565 @@
+{
+  "containers": [
+    {
+      "arguments": [],
+      "body": [
+        {
+          "function": {
+            "name": "derived_types_02__main__assign__x__0",
+            "type": "lambda"
+          },
+          "input": [],
+          "output": [
+            "@variable::x::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__assign__var_i___2",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::var::0"
+          ],
+          "output": [
+            "@variable::var_i::-2"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "@container::derived-types-02::main::loop$0",
+            "type": "container"
+          },
+          "input": [
+            "@variable::i::0"
+          ],
+          "output": [],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "@container::derived-types-02::main::loop$2",
+            "type": "container"
+          },
+          "input": [
+            "@variable::i::1"
+          ],
+          "output": [],
+          "updated": []
+        }
+      ],
+      "name": "@container::derived-types-02::@global::main",
+      "repeat": false,
+      "return_value": [],
+      "source_refs": [],
+      "updated": []
+    },
+    {
+      "arguments": [
+        "@variable::i::-1"
+      ],
+      "body": [
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_0__assign__i__0",
+            "type": "lambda"
+          },
+          "input": [],
+          "output": [
+            "@variable::i::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_0__condition__IF_0__0",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::i::0",
+            "@variable::i::-1"
+          ],
+          "output": [
+            "@variable::IF_0::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_0__decision__EXIT__0",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::IF_0::0"
+          ],
+          "output": [
+            "@variable::EXIT::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_0__assign__var_a_i__0",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::var_a::-1",
+            "@variable::i::0"
+          ],
+          "output": [
+            "@variable::var_a::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "@container::derived-types-02::main.loop$0::loop$1",
+            "type": "container"
+          },
+          "input": [
+            "@variable::i::0",
+            "@variable::a::0"
+          ],
+          "output": [],
+          "updated": [
+            "@variable::a::1"
+          ]
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_0__assign_i__1",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::i::0"
+          ],
+          "output": [
+            "@variable::i::1"
+          ],
+          "updated": []
+        }
+      ],
+      "name": "@container::derived-types-02::main::loop$0",
+      "repeat": true,
+      "return_value": [],
+      "source_refs": [],
+      "updated": []
+    },
+    {
+      "arguments": [
+        "@variable::i::-1",
+        "@variable::a::-1"
+      ],
+      "body": [
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_0__loop_1__assign__j__0",
+            "type": "lambda"
+          },
+          "input": [],
+          "output": [
+            "@variable::j::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_0__loop_1__condition__IF_0__0",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::j::0",
+            "@variable::i::-1"
+          ],
+          "output": [
+            "@variable::IF_0::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_0__loop_1__decision__EXIT__0",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::IF_0::0"
+          ],
+          "output": [
+            "@variable::EXIT::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_0__loop_1__assign__a_j__0",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::a::-1",
+            "@variable::j::0",
+            "@variable::i::-1"
+          ],
+          "output": [
+            "@variable::a::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_0__loop_1__assign_j__1",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::j::0"
+          ],
+          "output": [
+            "@variable::j::1"
+          ],
+          "updated": []
+        }
+      ],
+      "name": "@container::derived-types-02::main.loop$0::loop$1",
+      "repeat": true,
+      "return_value": [],
+      "source_refs": [],
+      "updated": [
+        "@variable::a::0"
+      ]
+    },
+    {
+      "arguments": [
+        "@variable::i::-1"
+      ],
+      "body": [
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_2__assign__i__0",
+            "type": "lambda"
+          },
+          "input": [],
+          "output": [
+            "@variable::i::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_2__condition__IF_0__0",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::i::0",
+            "@variable::i::-1"
+          ],
+          "output": [
+            "@variable::IF_0::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_2__decision__EXIT__0",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::IF_0::0"
+          ],
+          "output": [
+            "@variable::EXIT::0"
+          ],
+          "updated": []
+        },
+        {
+          "function": {
+            "name": "derived_types_02__main__loop_2__assign_i__1",
+            "type": "lambda"
+          },
+          "input": [
+            "@variable::i::0"
+          ],
+          "output": [
+            "@variable::i::1"
+          ],
+          "updated": []
+        }
+      ],
+      "name": "@container::derived-types-02::main::loop$2",
+      "repeat": true,
+      "return_value": [],
+      "source_refs": [],
+      "updated": []
+    }
+  ],
+  "grounding": [],
+  "source": [
+    "derived-types-02.f"
+  ],
+  "source_comments": {
+    "$file_foot": [],
+    "$file_head": []
+  },
+  "start": [
+    "@container::derived-types-02::@global::main"
+  ],
+  "types": [
+    [
+      {
+        "attributes": [
+          {
+            "name": "i",
+            "type": "integer"
+          },
+          {
+            "dimensions": [
+              4
+            ],
+            "elem_type": "float",
+            "name": "a",
+            "type": "Array"
+          }
+        ],
+        "name": "@type::derived-types-02::@global::mytype",
+        "type": "type"
+      }
+    ]
+  ],
+  "variables": [
+    {
+      "domain": {
+        "mutable": false,
+        "name": "mytype",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main::var::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "dimensions": [
+          4
+        ],
+        "elem_type": "mytype",
+        "index": 0,
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main::x::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "integer",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main::var_i::-2",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "dimensions": [
+          4
+        ],
+        "elem_type": "float",
+        "index": 0,
+        "mutable": true
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0::var_a_i::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "dimensions": [
+          4
+        ],
+        "elem_type": "float",
+        "index": 0,
+        "mutable": true
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::a_j::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "integer",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::i::-1",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "dimensions": [
+          4
+        ],
+        "elem_type": "float",
+        "index": 0,
+        "mutable": true
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::a::-1",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "dimensions": [
+          4
+        ],
+        "elem_type": "float",
+        "index": 0,
+        "mutable": true
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0::a::1",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "integer",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::j::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "boolean",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::IF_0::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "boolean",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::EXIT::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "integer",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::j::1",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "integer",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0::i::-1",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "integer",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0::i::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "boolean",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0::IF_0::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "boolean",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0::EXIT::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "integer",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$0::i::1",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "integer",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$2::i::-1",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "integer",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$2::i::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "boolean",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$2::IF_0::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "boolean",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$2::EXIT::0",
+      "source_refs": []
+    },
+    {
+      "domain": {
+        "mutable": false,
+        "name": "integer",
+        "type": "type"
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))",
+      "name": "@variable::derived-types-02::main.loop$2::i::1",
+      "source_refs": []
+    }
+  ]
+}

--- a/tests/data/program_analysis/derived-types/derived-types-02_lambdas.py
+++ b/tests/data/program_analysis/derived-types/derived-types-02_lambdas.py
@@ -1,0 +1,57 @@
+from numbers import Real
+from random import random
+from delphi.translators.for2py.strings import *
+import delphi.translators.for2py.math_ext as math
+
+def derived_types_02__main__assign__x__0():
+    x = [0] * (3 - 0)
+    return x
+
+def derived_types_02__main__assign__var_i___2(var: mytype):
+    var.i = 3
+    return var.i
+
+def derived_types_02__main__loop_0__assign__i__0():
+    return 1
+
+def derived_types_02__main__loop_0__condition__IF_0__0(i):
+    return 0 <= i < i
+
+def derived_types_02__main__loop_0__decision__EXIT__0(IF_0_0):
+    return IF_0_0
+
+def derived_types_02__main__loop_0__assign__var_a_i__0(var: mytype, i: int):
+    var.a[i] = (i+i)
+    return var.a[i]
+
+def derived_types_02__main__loop_0__loop_1__assign__j__0():
+    return 1
+
+def derived_types_02__main__loop_0__loop_1__condition__IF_0__0(j, i):
+    return 0 <= j < i
+
+def derived_types_02__main__loop_0__loop_1__decision__EXIT__0(IF_0_0):
+    return IF_0_0
+
+def derived_types_02__main__loop_0__loop_1__assign__a_j__0(a, j: int, i: int):
+    a[j] = ((i+j)/2.0)
+    return a[j]
+
+def derived_types_02__main__loop_0__loop_1__assign_j__1(j):
+    return j + 1
+
+def derived_types_02__main__loop_0__assign_i__1(i):
+    return i + 1
+
+def derived_types_02__main__loop_2__assign__i__0():
+    return 1
+
+def derived_types_02__main__loop_2__condition__IF_0__0(i):
+    return 0 <= i < i
+
+def derived_types_02__main__loop_2__decision__EXIT__0(IF_0_0):
+    return IF_0_0
+
+def derived_types_02__main__loop_2__assign_i__1(i):
+    return i + 1
+


### PR DESCRIPTION
This PR holds additional array features that appeared in the DSSAT code.
Specifically, codes appear in`delphi/tests/data/program_analysis/multifile_multimod/mfmm_01/ModuleDefs.for` file.

These features include:
1. A variable name is given as derived type array attribute size.
2. Multiple array declarations in the derived type.
3. Multi-dimensional array declarations in the derived type.

With these updates, we should be able to handle all derived type array cases in `ModuleDefs.for`
as well as other derived type cases (handled in #413).