### PR TITLE
Rm temp files

### DIFF
--- a/delphi/GrFN/networks.py
+++ b/delphi/GrFN/networks.py
@@ -434,7 +434,7 @@ class GroundedFunctionNetwork(ComputationalGraph):
         tester_call = True
         network_test = True
         """Builds GrFN object from Python source code."""
-        pgm_dict, generated_files = f2grfn.generate_grfn(
+        pgm_dict = f2grfn.generate_grfn(
                                         pySrc,
                                         python_file,
                                         lambdas_path,
@@ -445,10 +445,9 @@ class GroundedFunctionNetwork(ComputationalGraph):
                                         module_log_file_path,
                                         processing_modules,
                                         save_file
-                                    )
+        )
         lambdas = importlib.__import__(stem + "_lambdas")
         """Add generated GrFN and lambdas file paths to the list"""
-        generated_files_list.extend(generated_files)
         return cls.from_dict(pgm_dict, lambdas)
 
     @classmethod
@@ -496,8 +495,8 @@ class GroundedFunctionNetwork(ComputationalGraph):
                                     generated_files,
                                     save_file=save_file)
 
-            """Return GrFN and generated files list for cleanup"""
-            return G, generated_files
+            """Return GrFN object"""
+            return G
 
     @classmethod
     def from_fortran_src(cls, fortran_src: str, dir: str = "."):

--- a/delphi/translators/for2py/f2grfn.py
+++ b/delphi/translators/for2py/f2grfn.py
@@ -420,9 +420,10 @@ def generate_grfn(
             original_fortran_file
     )
 
-    log_generated_files([grfn_file, lambdas_file_path])
+    log_generated_files([grfn_file])
     if tester_call:
-        return grfn_dict, GENERATED_FILE_PATHS
+        cleanup_files(GENERATED_FILE_PATHS)
+        return grfn_dict
     else:
         # Write GrFN JSON into a file.
         with open(grfn_file, "w") as file_handle:
@@ -725,7 +726,7 @@ def fortran_to_grfn(
     except IOError:
         assert False, "Unable to write to file: {preprocessed_fortran_file}"
 
-    log_generated_files([system_json_path, preprocessed_fortran_file])
+    log_generated_files([preprocessed_fortran_file])
     
     # Generate OFP XML from preprocessed fortran
     ofp_xml = generate_ofp_xml(

--- a/tests/aske/test_GrFN.py
+++ b/tests/aske/test_GrFN.py
@@ -16,75 +16,52 @@ sys.path.insert(0, "tests/data/program_analysis")
 
 @pytest.fixture
 def crop_yield_grfn():
-    # Return two things:
-    # (1) Index [0]: GrFN object.
-    # (2) Index [1]: List of all generated files during processing Fortran file to GrFN.
     return GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/crop_yield.f")
 
 
 @pytest.fixture
 def petpt_grfn():
-    # Return two things:
-    # (1) Index [0]: GrFN object.
-    # (2) Index [1]: List of all generated files during processing Fortran file to GrFN.
     return GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/PETPT.for")
 
 
 @pytest.fixture
 def petasce_grfn():
-    # Return two things:
-    # (1) Index [0]: GrFN object.
-    # (2) Index [1]: List of all generated files during processing Fortran file to GrFN.
     return GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/PETASCE_simple.for")
 
 
 @pytest.fixture
 def sir_simple_grfn():
-    # Return two things:
-    # (1) Index [0]: GrFN object.
-    # (2) Index [1]: List of all generated files during processing Fortran file to GrFN.
     return GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/SIR-simple.f")
 
 
 @pytest.fixture
 def sir_gillespie_inline_grfn():
-    # Return two things:
-    # (1) Index [0]: GrFN object.
-    # (2) Index [1]: List of all generated files during processing Fortran file to GrFN.
     return GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/SIR-Gillespie-SD_inline.f")
 
 
 @pytest.fixture
 def sir_gillespie_ms_grfn():
-    # Return two things:
-    # (1) Index [0]: GrFN object.
-    # (2) Index [1]: List of all generated files during processing Fortran file to GrFN.
     return GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/SIR-Gillespie-MS.f")
 
 
 def test_petpt_creation_and_execution(petpt_grfn):
-    A = petpt_grfn[0].to_agraph()
+    A = petpt_grfn.to_agraph()
     A.draw("PETPT--GrFN.pdf", prog="dot")
-    CAG = petpt_grfn[0].to_CAG_agraph()
+    CAG = petpt_grfn.to_CAG_agraph()
     CAG.draw('PETPT--CAG.pdf', prog='dot')
-    assert isinstance(petpt_grfn[0], GroundedFunctionNetwork)
-    assert len(petpt_grfn[0].inputs) == 5
-    assert len(petpt_grfn[0].outputs) == 1
+    assert isinstance(petpt_grfn, GroundedFunctionNetwork)
+    assert len(petpt_grfn.inputs) == 5
+    assert len(petpt_grfn.outputs) == 1
 
-    values = {name: 1.0 for name in petpt_grfn[0].inputs}
-    res = petpt_grfn[0].run(values)
+    values = {name: 1.0 for name in petpt_grfn.inputs}
+    res = petpt_grfn.run(values)
     assert res[0] == np.float32(0.029983712)
-
-    # Since each test function is at the final phase of the test,
-    # the program needs to maintain the files and list up to here.
-    # Then, clean up all files based on the list before ending the test.
-    f2grfn.cleanup_files(petpt_grfn[1])
 
 
 def test_petasce_creation(petasce_grfn):
-    A = petasce_grfn[0].to_agraph()
-    CAG = petasce_grfn[0].to_CAG_agraph()
-    CG = petasce_grfn[0].to_call_agraph()
+    A = petasce_grfn.to_agraph()
+    CAG = petasce_grfn.to_CAG_agraph()
+    CG = petasce_grfn.to_call_agraph()
     A.draw('PETASCE--GrFN.pdf', prog='dot')
     CAG.draw('PETASCE--CAG.pdf', prog='dot')
 
@@ -104,54 +81,48 @@ def test_petasce_creation(petasce_grfn):
         "PETASCE_simple::@global::petasce::0::canht::-1": 2.0,
     }
 
-    res = petasce_grfn[0].run(values)
-    assert res[0] == np.float32(0.00012496980836348878)
-    f2grfn.cleanup_files(petasce_grfn[1])
+    res = petasce_grfn.run(values)
+    assert res == np.float32(0.00012496980836348878)
 
 
 def test_crop_yield_creation(crop_yield_grfn):
-    assert isinstance(crop_yield_grfn[0], GroundedFunctionNetwork)
-    G = crop_yield_grfn[0].to_agraph()
+    assert isinstance(crop_yield_grfn, GroundedFunctionNetwork)
+    G = crop_yield_grfn.to_agraph()
     G.draw('crop_yield--GrFN.pdf', prog='dot')
-    CAG = crop_yield_grfn[0].to_CAG_agraph()
+    CAG = crop_yield_grfn.to_CAG_agraph()
     CAG.draw('crop_yield--CAG.pdf', prog='dot')
-    f2grfn.cleanup_files(crop_yield_grfn[1])
 
 
 def test_sir_simple_creation(sir_simple_grfn):
-    assert isinstance(sir_simple_grfn[0], GroundedFunctionNetwork)
-    G = sir_simple_grfn[0].to_agraph()
+    assert isinstance(sir_simple_grfn, GroundedFunctionNetwork)
+    G = sir_simple_grfn.to_agraph()
     G.draw('SIR-simple--GrFN.pdf', prog='dot')
-    CAG = sir_simple_grfn[0].to_CAG_agraph()
+    CAG = sir_simple_grfn.to_CAG_agraph()
     CAG.draw('SIR-simple--CAG.pdf', prog='dot')
     # This importlib look up the lambdas file. Thus, the program must
     # maintain the files up to this level before clean up.
     lambdas = importlib.__import__(f"SIR-simple_lambdas")
-    (D, I, S, F) = GrFN2WD.to_wiring_diagram(sir_simple_grfn[0], lambdas)
+    (D, I, S, F) = GrFN2WD.to_wiring_diagram(sir_simple_grfn, lambdas)
     assert len(D) == 3
     assert len(I) == 3
     assert len(S) == 9
     assert len(F) == 5
-    # File cleanup.
-    f2grfn.cleanup_files(sir_simple_grfn[1])
 
 
 def test_sir_gillespie_inline_creation(sir_gillespie_inline_grfn):
-    assert isinstance(sir_gillespie_inline_grfn[0], GroundedFunctionNetwork)
-    G = sir_gillespie_inline_grfn[0].to_agraph()
+    assert isinstance(sir_gillespie_inline_grfn, GroundedFunctionNetwork)
+    G = sir_gillespie_inline_grfn.to_agraph()
     G.draw('SIR-Gillespie_inline--GrFN.pdf', prog='dot')
-    CAG = sir_gillespie_inline_grfn[0].to_CAG_agraph()
+    CAG = sir_gillespie_inline_grfn.to_CAG_agraph()
     CAG.draw('SIR-Gillespie_inline--CAG.pdf', prog='dot')
-    f2grfn.cleanup_files(sir_gillespie_inline_grfn[1])
 
 
 def test_sir_gillespie_ms_creation(sir_gillespie_ms_grfn):
-    assert isinstance(sir_gillespie_ms_grfn[0], GroundedFunctionNetwork)
-    G = sir_gillespie_ms_grfn[0].to_agraph()
+    assert isinstance(sir_gillespie_ms_grfn, GroundedFunctionNetwork)
+    G = sir_gillespie_ms_grfn.to_agraph()
     G.draw('SIR-Gillespie_ms--GrFN.pdf', prog='dot')
-    CAG = sir_gillespie_ms_grfn[0].to_CAG_agraph()
+    CAG = sir_gillespie_ms_grfn.to_CAG_agraph()
     CAG.draw('SIR-Gillespie_ms--CAG.pdf', prog='dot')
-    f2grfn.cleanup_files(sir_gillespie_ms_grfn[1])
 
 
 def test_linking_graph():

--- a/tests/aske/test_analysis.py
+++ b/tests/aske/test_analysis.py
@@ -33,7 +33,7 @@ def test_regular_PETPT(petpt_grfn):
     }
 
     Ns = 1000
-    Si = petpt_grfn[0].sobol_analysis(Ns, problem)
+    Si = petpt_grfn.sobol_analysis(Ns, problem)
     assert len(Si.keys()) == 6
     assert len(Si["S1"]) == len(args)
 
@@ -113,7 +113,7 @@ def test_PETASCE_sobol_analysis(petasce_grfn):
         'bounds': [bounds[arg] for arg in args]
     }
 
-    Si = petasce_grfn[0].sobol_analysis(100, problem, var_types=type_info)
+    Si = petasce_grfn.sobol_analysis(100, problem, var_types=type_info)
     assert len(Si["S1"]) == len(petasce_grfn.inputs)
     assert len(Si["S2"][0]) == len(petasce_grfn.inputs)
 

--- a/tests/aske/test_analysis.py
+++ b/tests/aske/test_analysis.py
@@ -17,7 +17,7 @@ sys.path.insert(0, "tests/data/program_analysis")
 
 
 def test_regular_PETPT(petpt_grfn):
-    args = petpt_grfn[0].inputs
+    args = petpt_grfn.inputs
     bounds = {
         "PETPT::@global::petpt::0::msalb::-1": [0, 1],
         "PETPT::@global::petpt::0::srad::-1": [1, 20],
@@ -36,7 +36,6 @@ def test_regular_PETPT(petpt_grfn):
     Si = petpt_grfn[0].sobol_analysis(Ns, problem)
     assert len(Si.keys()) == 6
     assert len(Si["S1"]) == len(args)
-    f2grfn.cleanup_files(petpt_grfn[1])
 
 
 @pytest.mark.skip("Need to update to latest JSON")
@@ -107,7 +106,7 @@ def test_PETASCE_sobol_analysis(petasce_grfn):
         "PETASCE_simple::@global::petasce::0::canht::-1": (float, [0.0]),
     }
 
-    args = petasce_grfn[0].inputs
+    args = petasce_grfn.inputs
     problem = {
         'num_vars': len(args),
         'names': args,
@@ -115,9 +114,8 @@ def test_PETASCE_sobol_analysis(petasce_grfn):
     }
 
     Si = petasce_grfn[0].sobol_analysis(100, problem, var_types=type_info)
-    assert len(Si["S1"]) == len(petasce_grfn[0].inputs)
-    assert len(Si["S2"][0]) == len(petasce_grfn[0].inputs)
-    f2grfn.cleanup_files(petasce_grfn[1])
+    assert len(Si["S1"]) == len(petasce_grfn.inputs)
+    assert len(Si["S2"][0]) == len(petasce_grfn.inputs)
 
 
 @pytest.mark.skip("Need to update to latest JSON")
@@ -188,20 +186,19 @@ def test_PETPT_sensitivity_surface(petpt_grfn):
         "PETPT::@global::petpt::0::xhlai::-1": 10,
     }
 
-    (X, Y, Z, x_var, y_var) = petpt_grfn[0].S2_surface((80, 60), bounds, presets)
+    (X, Y, Z, x_var, y_var) = petpt_grfn.S2_surface((80, 60), bounds, presets)
 
     assert X.shape == (80,)
     assert Y.shape == (60,)
     assert Z.shape == (80, 60)
-    f2grfn.cleanup_files(petpt_grfn[1])
 
 
 @pytest.mark.skip("Need to update FIB for new GrFN schema")
 def test_FIB_execution(petpt_grfn, petasce_grfn):
-    petpt_fib = petpt_grfn[0].to_FIB(petasce_grfn)
-    petasce_fib = petasce_grfn[0].to_FIB(petpt_grfn)
+    petpt_fib = petpt_grfn.to_FIB(petasce_grfn)
+    petasce_fib = petasce_grfn.to_FIB(petpt_grfn)
 
-    pt_inputs = {name: 1 for name in petpt_grfn[0].inputs}
+    pt_inputs = {name: 1 for name in petpt_grfn.inputs}
 
     asce_inputs = {
         "PETASCE_simple::@global::petasce::0::msalb::-1": 0.5,
@@ -229,5 +226,3 @@ def test_FIB_execution(petpt_grfn, petasce_grfn):
 
     res = petasce_fib[0].run(asce_inputs, asce_covers)
     assert res[0] == np.float32(0.00012496980836348878)
-    f2grfn.cleanup_files(petpt_grfn[1])
-    f2grfn.cleanup_files(petasce_grfn[1])

--- a/tests/aske/test_program_analysis.py
+++ b/tests/aske/test_program_analysis.py
@@ -52,7 +52,7 @@ def make_grfn_dict(original_fortran_file) -> Dict:
     for python_file_path in python_file_paths:
         python_file_path_wo_extension = python_file_path[0:-3]
         lambdas_file_path  = python_file_path_wo_extension + lambda_file_suffix
-        _dict, generated_files = f2grfn.generate_grfn(
+        _dict = f2grfn.generate_grfn(
                                         pySrc[0][0],
                                         python_file_path,
                                         lambdas_file_path,
@@ -63,7 +63,7 @@ def make_grfn_dict(original_fortran_file) -> Dict:
                                         module_log_file_path,
                                         processing_modules,
                                         save_file
-                                 )
+        )
        
         # This blocks system.json to be fully populated.
         # Since the purpose of test_program_analysis is to compare
@@ -71,8 +71,7 @@ def make_grfn_dict(original_fortran_file) -> Dict:
         # return as it is to return the only one translated GrFN string.
         return (
                 json.dumps(_dict, sort_keys=True, indent=2),
-                lambdas_file_path,
-                generated_files
+                lambdas_file_path
         )
 
 
@@ -339,8 +338,6 @@ def test_multidimensional_array_grfn_generation(multidimensional_array_test):
         generated_lamdba_functions = l.read()
     assert str(target_lambda_functions) == str(generated_lamdba_functions)
 
-    f2grfn.cleanup_files(multidimensional_array_test[2])
-
 
 def test_sir_gillespie_sd_multi_grfn_generation(sir_gillespie_sd_multi_test):
     with open(f"{DATA_DIR}/SIR-Gillespie-SD_multi_module_GrFN.json", "r") as f:
@@ -352,8 +349,6 @@ def test_sir_gillespie_sd_multi_grfn_generation(sir_gillespie_sd_multi_test):
     with open(f"{TEMP_DIR}/{sir_gillespie_sd_multi_test[1]}", "r") as l:
         generated_lamdba_functions = l.read()
     assert str(target_lambda_functions) == str(generated_lamdba_functions)
-
-    f2grfn.cleanup_files(sir_gillespie_sd_multi_test[2])
 
 
 def test_derived_type_grfn_generation(derived_type_grfn_test):
@@ -367,8 +362,6 @@ def test_derived_type_grfn_generation(derived_type_grfn_test):
         generated_lamdba_functions = l.read()
     assert str(target_lambda_functions) == str(generated_lamdba_functions)
 
-    f2grfn.cleanup_files(derived_type_grfn_test[2])
-
 def test_derived_type_array_grfn_generation(derived_type_array_grfn_test):
     with open(f"{DATA_DIR}/derived-types/derived-types-02_GrFN.json", "r") as f:
         grfn_dict = f.read()
@@ -379,5 +372,3 @@ def test_derived_type_array_grfn_generation(derived_type_array_grfn_test):
     with open(f"{TEMP_DIR}/{derived_type_array_grfn_test[1]}", "r") as l:
         generated_lamdba_functions = l.read()
     assert str(target_lambda_functions) == str(generated_lamdba_functions)
-
-    f2grfn.cleanup_files(derived_type_array_grfn_test[2])

--- a/tests/aske/test_webapp.py
+++ b/tests/aske/test_webapp.py
@@ -7,13 +7,11 @@ def test_PETPT_GrFN_wiring(petpt_grfn):
     with open("tests/data/GrFN/petpt_grfn_edges.txt", newline="") as csvfile:
         reader = csv.reader(csvfile)
         edges = {tuple(r) for r in reader}
-    assert edges == set(petpt_grfn[0].edges())
-    f2grfn.cleanup_files(petpt_grfn[1])
+    assert edges == set(petpt_grfn.edges())
 
 
 def test_PETPT_CAG_wiring(petpt_grfn):
     with open("tests/data/GrFN/petpt_cag_edges.txt", newline="") as csvfile:
         reader = csv.reader(csvfile)
         edges = {tuple(r) for r in reader}
-    assert edges == set(petpt_grfn[0].to_CAG().edges())
-    f2grfn.cleanup_files(petpt_grfn[1])
+    assert edges == set(petpt_grfn.to_CAG().edges())


### PR DESCRIPTION
This PR holds updates in GrFN test programs to no longer handle removing temporary files
that were generated during `f2grfn` process, and this removal process is done at the end of
`generate_grfn` function of `f2grfn.py`.

With this update, only files that will be left are as follows:
- `*_lambdas.py`: A file that holds lambda functions.
- `system.json`: A file that holds multiple GrFN linking information.
- `modFileLog.json`: A file that holds information of modules, such as file name, path, last updated time.

Any other files, such as `*_pickle`, `*.xml`, Python IR, and etc, will be removed if GrFN test was successfully completed.