### PR TITLE
character under derived types

### DIFF
--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -33,7 +33,7 @@ from delphi.translators.for2py import For2PyError, syntax
 
 # TYPE_MAP gives the mapping from Fortran types to Python types
 TYPE_MAP = {
-    "character": "str",
+#     "character": "str",
     "double": "float",
     "float": "float",
     "int": "int",
@@ -1346,7 +1346,13 @@ class PythonCodeGenerator(object):
 
             if derived_type_variables[var]["is_array"] == "false":
                 if not is_derived_type_declaration:
-                    self.pyStrings.append(f"        self.{name} : {var_type}")
+                    if var_type == "String":
+                        str_length = derived_type_variables[var]["length"]
+                        self.pyStrings.append(
+                            f"        self.{name} = {var_type}({str_length})"
+                        )
+                    else:
+                        self.pyStrings.append(f"        self.{name} : {var_type}")
                 else:
                     self.pyStrings.append(
                         f"        self.{name} = {var_type}()"
@@ -1691,6 +1697,8 @@ class PythonCodeGenerator(object):
             return mapped_type
         else:
             if node["is_derived_type"] == "true":
+                if variable_type == "character":
+                    variable_type = "String"
                 self.var_type.setdefault(self.current_module, []).append({
                     "name": var_name,
                     "type": variable_type

--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -656,6 +656,8 @@ class PythonCodeGenerator(object):
         try:
             if node["type"].lower() in TYPE_MAP:
                 var_type = TYPE_MAP[node["type"].lower()]
+            elif node["type"].lower() == "character":
+                var_type = "str"
             elif node["is_derived_type"] == "true":
                 var_type = node["type"].lower()
         except KeyError:
@@ -666,7 +668,6 @@ class PythonCodeGenerator(object):
             "type": node["type"],
             "parameter": False,
         }
-
         self.var_type.setdefault(self.current_module, []).append({
             "name": arg_name,
             "type": var_type

--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -33,7 +33,7 @@ from delphi.translators.for2py import For2PyError, syntax
 
 # TYPE_MAP gives the mapping from Fortran types to Python types
 TYPE_MAP = {
-#     "character": "str",
+#    "character": "str",
     "double": "float",
     "float": "float",
     "int": "int",
@@ -1690,19 +1690,13 @@ class PythonCodeGenerator(object):
         if variable_type in TYPE_MAP:
             mapped_type = TYPE_MAP[variable_type]
             if node.get("is_derived_type") == "false":
-                self.var_type.setdefault(self.current_module, []).append({
-                    "name": var_name,
-                    "type": mapped_type
-                })
+                self.set_default_var_type(var_name, mapped_type)
             return mapped_type
         else:
             if node["is_derived_type"] == "true":
                 if variable_type == "character":
                     variable_type = "String"
-                self.var_type.setdefault(self.current_module, []).append({
-                    "name": var_name,
-                    "type": variable_type
-                })
+                self.set_default_var_type(var_name, variable_type)
                 # Add each element of the derived type into self.var_type as
                 # well
                 if variable_type in self.var_type:
@@ -1711,9 +1705,25 @@ class PythonCodeGenerator(object):
                             "name": f"{var_name}.{var['name']}",
                             "type": var['type']
                         })
-                return variable_type
+            elif (
+                    node["is_derived_type"] == "false"
+                    and variable_type == "character"
+            ):
+                variable_type == "str"
+                self.set_default_var_type(var_name, variable_type)
             else:
                 assert False, f"Unrecognized variable type: {variable_type}"
+
+            return variable_type
+
+    def set_default_var_type(self, var_name, var_type):
+        """ Thu=is function sets the default variable type of the declared
+        variable."""
+
+        self.var_type.setdefault(self.current_module, []).append({
+            "name": var_name,
+            "type": var_type
+        })
 
     def get_array_dimension(self, node):
         """ This function is for extracting the dimensions' range information

--- a/delphi/translators/for2py/pyTranslate.py
+++ b/delphi/translators/for2py/pyTranslate.py
@@ -1718,7 +1718,7 @@ class PythonCodeGenerator(object):
             return variable_type
 
     def set_default_var_type(self, var_name, var_type):
-        """ Thu=is function sets the default variable type of the declared
+        """ This function sets the default variable type of the declared
         variable."""
 
         self.var_type.setdefault(self.current_module, []).append({

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -3382,7 +3382,7 @@ class RectifyOFPXML:
                         "keyword2": keyword2,
                     }
                     newType = ET.SubElement(derived_type, "type", attributes)
-                    if newType.attrib['name'] == "character":
+                    if newType.attrib['name'].lower() == "character":
                         assert (
                             literal_value != None
                         ), "Literal value (String length) for character cannot be None."

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -1071,6 +1071,7 @@ class RectifyOFPXML:
                 if self.is_character:
                     self.derived_type_var_holder_list.append(child)
                     self.str_lengths.append(str(child.attrib["value"]))
+                    current.set("string_length", str(child.attrib["value"]))
                 elif is_derived_type_dimension_setting:
                     child.attrib["dim-number"] = str(dim_number)
                     self.derived_type_array_dimensions[self.dim].append(child)

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -951,6 +951,7 @@ class RectifyOFPXML:
                 elif (
                         child.tag == "component-decl"
                         or child.tag == "component-decl-list"
+                        or child.tag == "component-decl-list__begin"
                 ):
                     current.attrib['type'] = "derived-type"
                     self.derived_type_var_holder_list.append(child)
@@ -1085,6 +1086,7 @@ class RectifyOFPXML:
             elif (
                     child.tag == "component-decl"
                     or child.tag == "component-decl-list"
+                    or child.tag == "component-decl-list__begin"
             ):
                 self.derived_type_var_holder_list.append(child)
             elif child.tag == "length":
@@ -3363,6 +3365,8 @@ class RectifyOFPXML:
             # declarations will follow.
             derived_type = ET.SubElement(self.parent_type, "derived-types")
             for elem in self.derived_type_var_holder_list:
+                # DEBUG
+                print ("    elem: ", elem)
                 if elem.tag == "intrinsic-type-spec":
                     keyword2 = ""
                     if elem.attrib['keyword2'] == "":

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -3365,8 +3365,6 @@ class RectifyOFPXML:
             # declarations will follow.
             derived_type = ET.SubElement(self.parent_type, "derived-types")
             for elem in self.derived_type_var_holder_list:
-                # DEBUG
-                print ("    elem: ", elem)
                 if elem.tag == "intrinsic-type-spec":
                     keyword2 = ""
                     if elem.attrib['keyword2'] == "":
@@ -3402,14 +3400,15 @@ class RectifyOFPXML:
                 elif elem.tag == "component-array-spec":
                     is_dimension = True
                     dim += 1
+                elif elem.tag == "component-decl-list__begin":
+                    if len(counts) > count:
+                        attr = {"count": counts[count]}
+                        new_variables = ET.SubElement(
+                            derived_type, "variables", attr
+                        )  # <variables _attribs_>
+                        count += 1
                 elif elem.tag == "component-decl":
                     if not is_dimension:
-                        if len(counts) > count:
-                            attr = {"count": counts[count]}
-                            new_variables = ET.SubElement(
-                                derived_type, "variables", attr
-                            )  # <variables _attribs_>
-                            count += 1
                         var_attribs = {
                             "has_initial_value": elem.attrib[
                                 "hasComponentInitialization"
@@ -3498,7 +3497,6 @@ class RectifyOFPXML:
                                     )  # <dimension type="simple">
                                     new_range = ET.SubElement(new_dimension, "range")
                                     need_new_dimension = False
-                                    
 
                         if len(counts) > count:
                             attr = {"count": counts[count]}

--- a/delphi/translators/for2py/rectify.py
+++ b/delphi/translators/for2py/rectify.py
@@ -471,6 +471,12 @@ class RectifyOFPXML:
         "operation",
     ]
 
+    dtype_var_declaration_tags = [
+        "component-decl",
+        "component-decl-list",
+        "component-decl-list__begin"
+    ]
+
     #################################################################
     #                                                               #
     #                       HANDLER FUNCTIONS                       #
@@ -1085,11 +1091,7 @@ class RectifyOFPXML:
                     self.derived_type_array_dimensions[self.dim].append(child)
             elif child.tag == "component-array-spec":
                 self.derived_type_var_holder_list.append(child)
-            elif (
-                    child.tag == "component-decl"
-                    or child.tag == "component-decl-list"
-                    or child.tag == "component-decl-list__begin"
-            ):
+            elif child.tag in self.dtype_var_declaration_tags:
                 self.derived_type_var_holder_list.append(child)
             elif child.tag == "length":
                 cur_elem = ET.SubElement(current, child.tag, child.attrib)

--- a/delphi/translators/for2py/translate.py
+++ b/delphi/translators/for2py/translate.py
@@ -422,24 +422,24 @@ class XML_to_JSON_translator(object):
                 elif node.tag == "derived-types":
                     derived_type[-1].update(self.parseTree(node, state))
             return derived_type
-        elif root.attrib["name"] == "character":
-            # Check if this is a string
-            declared_type = {
-                "type": root.attrib["name"],
-                "length": root.attrib["string_length"],
-                "is_derived_type": root.attrib["is_derived_type"].lower(),
-                "is_string": "true",
-                "keyword2": root.attrib["keyword2"],
-            }
-            return [declared_type]
         else:
-            # Else, this represents an empty element, which is the case of (1).
-            declared_type = {
-                "type": root.attrib["name"],
-                "is_derived_type": root.attrib["is_derived_type"].lower(),
-                "keyword2": root.attrib["keyword2"],
-                "is_string": "false",
-            }
+            if root.attrib["name"].lower() == "character":
+                # Check if this is a string
+                declared_type = {
+                    "type": root.attrib["name"],
+                    "length": root.attrib["string_length"],
+                    "is_derived_type": root.attrib["is_derived_type"].lower(),
+                    "is_string": "true",
+                    "keyword2": root.attrib["keyword2"],
+                }
+            else:
+                # Else, this represents an empty element, which is the case of (1).
+                declared_type = {
+                    "type": root.attrib["name"],
+                    "is_derived_type": root.attrib["is_derived_type"].lower(),
+                    "keyword2": root.attrib["keyword2"],
+                    "is_string": "false",
+                }
             return [declared_type]
 
     def process_length(self, root, state) -> List[Dict]:

--- a/tests/data/program_analysis/interface/interface_03.f
+++ b/tests/data/program_analysis/interface/interface_03.f
@@ -3,28 +3,28 @@
       INTEGER, PARAMETER :: MaxFiles = 500
 
       TYPE ControlType
-        CHARACTER (len=1)  MESIC
+        CHARACTER (len=1)  MESIC, RNMODE
         CHARACTER (len=2)  CROP
-        CHARACTER (len=8)  MODEL
+        CHARACTER (len=8)  MODEL, ENAME
         CHARACTER (len=12) FILEX
         CHARACTER (len=30) FILEIO
         CHARACTER (len=102)DSSATP
-        INTEGER   DAS
-        INTEGER   NYRS
-        INTEGER   YRDIF
+        INTEGER   DAS, DYNAMIC, FROP, ErrCode, LUNIO, MULTI, N_ELEMS
+        INTEGER   NYRS, REPNO, ROTNUM, RUN, TRTNUM
+        INTEGER   YRDIF, YRDOY, YRSIM
       END TYPE ControlType
 
       TYPE SwitchType
         CHARACTER (len=1) FNAME
-        CHARACTER (len=1) IDETC
-        CHARACTER (len=1) IDETO
-        CHARACTER (len=1) IHARI
-        CHARACTER (len=1) ISWCHE
-        CHARACTER (len=1) ISWPHO
-        CHARACTER (len=1) MEEVP
-        CHARACTER (len=1) MESOM
+        CHARACTER (len=1) IDETC, IDETD, IDETG, IDETH, IDETL, IDETN
+        CHARACTER (len=1) IDETO, IDETP, IDETR, IDETS, IDETW
+        CHARACTER (len=1) IHARI, IPLTI, IIRRI, ISIMI
+        CHARACTER (len=1) ISWCHE, ISWDIS, ISWNIT
+        CHARACTER (len=1) ISWPHO, ISWPOT, ISWSYM, ISWTIL, ISWWAT
+        CHARACTER (len=1) MEEVP, MEGHG, MEHYD, MEINF, MELI, MEPHO
+        CHARACTER (len=1) MESOM, MESOL, MESEV, MEWTH
         CHARACTER (len=1) METMP !Temperature, EPIC
-        CHARACTER (len=1) IFERI
+        CHARACTER (len=1) IFERI, IRESI, ICO2, FMOPT
         INTEGER NSWI
       END TYPE SwitchType
 

--- a/tests/data/program_analysis/interface/m_testmodule.py
+++ b/tests/data/program_analysis/interface/m_testmodule.py
@@ -15,28 +15,71 @@ from random import random
 class ControlType:
     def __init__(self):
         self.mesic = String(1)
+        self.rnmode = String(1)
         self.crop = String(2)
         self.model = String(8)
+        self.ename = String(8)
         self.filex = String(12)
         self.fileio = String(30)
         self.dssatp = String(102)
         self.das : int
+        self.dynamic : int
+        self.frop : int
+        self.errcode : int
+        self.lunio : int
+        self.multi : int
+        self.n_elems : int
         self.nyrs : int
+        self.repno : int
+        self.rotnum : int
+        self.run : int
+        self.trtnum : int
         self.yrdif : int
+        self.yrdoy : int
+        self.yrsim : int
 
 @dataclass
 class SwitchType:
     def __init__(self):
         self.fname = String(1)
         self.idetc = String(1)
+        self.idetd = String(1)
+        self.idetg = String(1)
+        self.ideth = String(1)
+        self.idetl = String(1)
+        self.idetn = String(1)
         self.ideto = String(1)
+        self.idetp = String(1)
+        self.idetr = String(1)
+        self.idets = String(1)
+        self.idetw = String(1)
         self.ihari = String(1)
+        self.iplti = String(1)
+        self.iirri = String(1)
+        self.isimi = String(1)
         self.iswche = String(1)
+        self.iswdis = String(1)
+        self.iswnit = String(1)
         self.iswpho = String(1)
+        self.iswpot = String(1)
+        self.iswsym = String(1)
+        self.iswtil = String(1)
+        self.iswwat = String(1)
         self.meevp = String(1)
+        self.meghg = String(1)
+        self.mehyd = String(1)
+        self.meinf = String(1)
+        self.meli = String(1)
+        self.mepho = String(1)
         self.mesom = String(1)
+        self.mesol = String(1)
+        self.mesev = String(1)
+        self.mewth = String(1)
         self.metmp = String(1)
         self.iferi = String(1)
+        self.iresi = String(1)
+        self.ico2 = String(1)
+        self.fmopt = String(1)
         self.nswi : int
 
 @dataclass

--- a/tests/data/program_analysis/interface/m_testmodule.py
+++ b/tests/data/program_analysis/interface/m_testmodule.py
@@ -14,12 +14,12 @@ from random import random
 @dataclass
 class ControlType:
     def __init__(self):
-        self.mesic : str
-        self.crop : str
-        self.model : str
-        self.filex : str
-        self.fileio : str
-        self.dssatp : str
+        self.mesic = String(1)
+        self.crop = String(2)
+        self.model = String(8)
+        self.filex = String(12)
+        self.fileio = String(30)
+        self.dssatp = String(102)
         self.das : int
         self.nyrs : int
         self.yrdif : int
@@ -27,16 +27,16 @@ class ControlType:
 @dataclass
 class SwitchType:
     def __init__(self):
-        self.fname : str
-        self.idetc : str
-        self.ideto : str
-        self.ihari : str
-        self.iswche : str
-        self.iswpho : str
-        self.meevp : str
-        self.mesom : str
-        self.metmp : str
-        self.iferi : str
+        self.fname = String(1)
+        self.idetc = String(1)
+        self.ideto = String(1)
+        self.ihari = String(1)
+        self.iswche = String(1)
+        self.iswpho = String(1)
+        self.meevp = String(1)
+        self.mesom = String(1)
+        self.metmp = String(1)
+        self.iferi = String(1)
         self.nswi : int
 
 @dataclass

--- a/tests/data/program_analysis/interface/m_testmodule.py
+++ b/tests/data/program_analysis/interface/m_testmodule.py
@@ -11,11 +11,52 @@ import delphi.translators.for2py.math_ext as math
 from numbers import Real
 from random import random
 
+@dataclass
+class ControlType:
+    def __init__(self):
+        self.mesic : str
+        self.crop : str
+        self.model : str
+        self.filex : str
+        self.fileio : str
+        self.dssatp : str
+        self.das : int
+        self.nyrs : int
+        self.yrdif : int
+
+@dataclass
+class SwitchType:
+    def __init__(self):
+        self.fname : str
+        self.idetc : str
+        self.ideto : str
+        self.ihari : str
+        self.iswche : str
+        self.iswpho : str
+        self.meevp : str
+        self.mesom : str
+        self.metmp : str
+        self.iferi : str
+        self.nswi : int
+
+@dataclass
+class TransferType:
+    def __init__(self):
+        self.control : controltype
+        self.iswitch : switchtype
+        self.output : outputtype
+        self.plant : planttype
+        self.mgmt : mgmttype
+        self.nitr : nitype
+        self.orgc : orgctype
+        self.soilprop : soiltype
+        self.spam : spamtype
+        self.water : wattype
+        self.weather : weathtype
+        self.pdlabeta : pdlabetatype
+
 
 maxfiles: List[int] = [500]
-
-
-
 save_data =  transfertype()
 def get (arg1=None):
     num_passed_args = 0


### PR DESCRIPTION
This PR holds fixes for the bugs in `character` (`String`) variable declaration
under derived types.

- `character` variables declare with a regular `str` types. For example,
     - `character (len=2) crop` to `crop : str` not `crop = Sting(2)`
- Multiple variables declared under a single type lead to an error. For example,
     - `character (len=8) model, ename`

Updated `interface_03.f` test file to include these handled cases.