### PR TITLE
Adding GrFN JSON output method

### DIFF
--- a/delphi/GrFN/networks.py
+++ b/delphi/GrFN/networks.py
@@ -555,8 +555,9 @@ class GroundedFunctionNetwork(ComputationalGraph):
                 nodes_json.append(
                     {
                         "name": name,
+                        "type": "variable",
                         "reference": None,
-                        "type": {
+                        "data-type": {
                             "name": "float32",
                             "domain": [("-inf", "inf")],
                         },
@@ -568,8 +569,9 @@ class GroundedFunctionNetwork(ComputationalGraph):
                 nodes_json.append(
                     {
                         "name": name,
-                        "inputs": data["func_inputs"],
+                        "type": "function",
                         "reference": None,
+                        "inputs": data["func_inputs"],
                         "lambda": source_code,
                     }
                 )

--- a/delphi/GrFN/networks.py
+++ b/delphi/GrFN/networks.py
@@ -576,12 +576,17 @@ class GroundedFunctionNetwork(ComputationalGraph):
             else:
                 raise ValueError(f"Unrecognized node type: {data['type']}")
 
-        json_data = {
-            "nodes": nodes_json,
-            "edges": list(self.edges),
-            "containers": list(containers.values()),
-        }
-        json.dump(json_data, open("GrFN.json", "w"))
+        return json.dumps(
+            {
+                "nodes": nodes_json,
+                "edges": list(self.edges),
+                "containers": list(containers.values()),
+            }
+        )
+
+    def to_json_file(self, filename):
+        GrFN_json = self.to_json()
+        json.dump(GrFN_json, open(filename, "w"))
 
     def to_AGraph(self):
         """ Export to a PyGraphviz AGraph object. """

--- a/delphi/GrFN/networks.py
+++ b/delphi/GrFN/networks.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Dict, Iterable, Set, Union
 from typing import List
@@ -26,19 +26,8 @@ forestgreen = "#228b22"
 
 
 class ComputationalGraph(nx.DiGraph):
-    __metaclass__ = ABCMeta
-
-    def __init__(self, network, output_vars, *args, **kwargs):
-        super().__init__(network, *args, **kwargs)
-        self.outputs = output_vars
-        self.inputs = [
-            n
-            for n, d in self.in_degree()
-            if d == 0 and self.nodes[n]["type"] == "variable"
-        ]
-        self.input_name_map = {
-            self.var_shortname(name): name for name in self.inputs
-        }
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.FCG = self.to_FCG()
         self.function_sets = self.build_function_sets()
 
@@ -178,7 +167,17 @@ class GroundedFunctionNetwork(ComputationalGraph):
     """
 
     def __init__(self, G, scope_tree, outputs):
-        super().__init__(G, outputs)
+        super().__init__(G)
+        self.outputs = outputs
+        self.inputs = [
+            n
+            for n, d in self.in_degree()
+            if d == 0 and self.nodes[n]["type"] == "variable"
+        ]
+        self.input_name_map = {
+            self.var_shortname(name): name for name in self.inputs
+        }
+        # self.outputs = outputs
         self.scope_tree = scope_tree
 
     def __repr__(self):
@@ -434,8 +433,20 @@ class GroundedFunctionNetwork(ComputationalGraph):
         cur_scope = ScopeNode(functions[root], occurrences[root])
         scope_tree.add_node(cur_scope.name, color="forestgreen")
         returns, updates = process_container(cur_scope, [], root)
-        G = cls(G, scope_tree, returns + updates)
-        return G
+        return cls(G, scope_tree, returns + updates)
+
+    @staticmethod
+    def create_container_dict(G: nx.DiGraph):
+        containers = {node_name: dict() for node_name in scope_tree.nodes}
+
+    @classmethod
+    def from_python_file(
+        cls, python_file, lambdas_path, json_filename: str, stem: str
+    ):
+        """Builds GrFN object from Python file."""
+        with open(python_file, "r") as f:
+            pySrc = f.read()
+        return cls.from_python_src(pySrc, lambdas_path, json_filename, stem)
 
     @classmethod
     def from_python_src(
@@ -446,7 +457,7 @@ class GroundedFunctionNetwork(ComputationalGraph):
         module_log_file_path: str,
         mod_mapper_dict: list,
         processing_modules: bool,
-        save_intermediate_files: bool = False,
+        save_file: bool = False,
     ):
         lambdas_path = python_file.replace(".py", "_lambdas.py")
         # Builds GrFN object from Python source code.
@@ -462,20 +473,18 @@ class GroundedFunctionNetwork(ComputationalGraph):
 
         G = cls.from_dict(pgm_dict, lambdas_path)
 
-        if not save_intermediate_files:
-            # Cleanup intermediate files.
-            variable_map_filename = python_file.replace(".py", "_variable_map.pkl")
-            rectified_xml_filename = "rectified_" + str(Path(python_file)).replace(
-                ".py", ".xml"
-            )
-            os.remove(variable_map_filename)
-            os.remove(rectified_xml_filename)
-
+        # Cleanup intermediate files.
+        variable_map_filename = python_file.replace(".py", "_variable_map.pkl")
+        os.remove(variable_map_filename)
+        rectified_xml_filename = "rectified_" + str(Path(python_file)).replace(
+            ".py", ".xml"
+        )
+        os.remove(rectified_xml_filename)
         return G
 
     @classmethod
     def from_fortran_file(
-        cls, fortran_file: str, tmpdir: str = ".", save_intermediate_files: bool = False
+        cls, fortran_file: str, tmpdir: str = ".", save_file: bool = False
     ):
         """Builds GrFN object from a Fortran program."""
 
@@ -493,7 +502,6 @@ class GroundedFunctionNetwork(ComputationalGraph):
             temp_dir=str(tmpdir),
             root_dir_path=root_dir,
             processing_modules=False,
-            save_intermediate_files = save_intermediate_files
         )
 
         # For now, just taking the first translated file.
@@ -506,7 +514,7 @@ class GroundedFunctionNetwork(ComputationalGraph):
             module_log_file_path,
             mod_mapper_dict,
             processing_modules,
-            save_intermediate_files = save_intermediate_files
+            save_file=save_file,
         )
 
         return G
@@ -532,6 +540,48 @@ class GroundedFunctionNetwork(ComputationalGraph):
         G = cls.from_fortran_file(fp.name, dir)
         os.remove(fp.name)
         return G
+
+    def to_json(self):
+        """Experimental outputting a GrFN to a JSON file."""
+        containers = {
+            name: {"name": name, "parent": None, "exit": True, "nodes": list()}
+            for name in self.scope_tree.nodes
+        }
+
+        nodes_json = list()
+        for name, data in self.nodes(data=True):
+            containers[data["parent"]]["nodes"].append(name)
+            if data["type"] == "variable":
+                nodes_json.append(
+                    {
+                        "name": name,
+                        "reference": None,
+                        "type": {
+                            "name": "float32",
+                            "domain": [("-inf", "inf")],
+                        },
+                    }
+                )
+            elif data["type"] == "function":
+                (source_list, _) = inspect.getsourcelines(data["lambda_fn"])
+                source_code = "".join(source_list)
+                nodes_json.append(
+                    {
+                        "name": name,
+                        "inputs": data["func_inputs"],
+                        "reference": None,
+                        "lambda": source_code,
+                    }
+                )
+            else:
+                raise ValueError(f"Unrecognized node type: {data['type']}")
+
+        json_data = {
+            "nodes": nodes_json,
+            "edges": list(self.edges),
+            "containers": list(containers.values()),
+        }
+        json.dump(json_data, open("GrFN.json", "w"))
 
     def to_AGraph(self):
         """ Export to a PyGraphviz AGraph object. """

--- a/tests/aske/test_GrFN.py
+++ b/tests/aske/test_GrFN.py
@@ -17,69 +17,83 @@ sys.path.insert(0, "tests/data/program_analysis")
 
 @pytest.fixture
 def crop_yield_grfn():
-    yield GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/crop_yield.f")
-    os.remove('crop_yield--GrFN.pdf')
-    os.remove('crop_yield--CAG.pdf')
+    yield GroundedFunctionNetwork.from_fortran_file(
+        "tests/data/program_analysis/crop_yield.f"
+    )
+    os.remove("crop_yield--GrFN.pdf")
+    os.remove("crop_yield--CAG.pdf")
 
 
 @pytest.fixture
 def petpt_grfn():
-    yield GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/PETPT.for")
+    yield GroundedFunctionNetwork.from_fortran_file(
+        "tests/data/program_analysis/PETPT.for"
+    )
 
 
 @pytest.fixture
 def petasce_grfn():
-    yield GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/PETASCE_simple.for")
-    os.remove('PETASCE--GrFN.pdf')
-    os.remove('PETASCE--CAG.pdf')
+    yield GroundedFunctionNetwork.from_fortran_file(
+        "tests/data/program_analysis/PETASCE_simple.for"
+    )
+    os.remove("PETASCE--GrFN.pdf")
+    os.remove("PETASCE--CAG.pdf")
 
 
 @pytest.fixture
 def sir_simple_grfn():
-    yield GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/SIR-simple.f")
-    os.remove('SIR-simple--GrFN.pdf')
-    os.remove('SIR-simple--CAG.pdf')
+    yield GroundedFunctionNetwork.from_fortran_file(
+        "tests/data/program_analysis/SIR-simple.f"
+    )
+    os.remove("SIR-simple--GrFN.pdf")
+    os.remove("SIR-simple--CAG.pdf")
 
 
 @pytest.fixture
 def sir_gillespie_inline_grfn():
-    yield GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/SIR-Gillespie-SD_inline.f")
-    os.remove('SIR-Gillespie_inline--CAG.pdf')
-    os.remove('SIR-Gillespie_inline--GrFN.pdf')
+    yield GroundedFunctionNetwork.from_fortran_file(
+        "tests/data/program_analysis/SIR-Gillespie-SD_inline.f"
+    )
+    os.remove("SIR-Gillespie_inline--CAG.pdf")
+    os.remove("SIR-Gillespie_inline--GrFN.pdf")
 
 
 @pytest.fixture
 def sir_gillespie_ms_grfn():
-    yield GroundedFunctionNetwork.from_fortran_file("tests/data/program_analysis/SIR-Gillespie-MS.f")
-    os.remove('SIR-Gillespie_ms--CAG.pdf')
-    os.remove('SIR-Gillespie_ms--GrFN.pdf')
+    yield GroundedFunctionNetwork.from_fortran_file(
+        "tests/data/program_analysis/SIR-Gillespie-MS.f"
+    )
+    os.remove("SIR-Gillespie_ms--CAG.pdf")
+    os.remove("SIR-Gillespie_ms--GrFN.pdf")
 
 
 def test_petpt_creation_and_execution(petpt_grfn):
     A = petpt_grfn.to_AGraph()
     A.draw("PETPT--GrFN.pdf", prog="dot")
     CAG = petpt_grfn.CAG_to_AGraph()
-    CAG.draw('PETPT--CAG.pdf', prog='dot')
+    CAG.draw("PETPT--CAG.pdf", prog="dot")
     assert isinstance(petpt_grfn, GroundedFunctionNetwork)
     assert len(petpt_grfn.inputs) == 5
     assert len(petpt_grfn.outputs) == 1
 
-    outputs = petpt_grfn.run({
-        name: np.array([1.0], dtype=np.float32)
-        for name in petpt_grfn.input_name_map.keys()
-    })
+    outputs = petpt_grfn.run(
+        {
+            name: np.array([1.0], dtype=np.float32)
+            for name in petpt_grfn.input_name_map.keys()
+        }
+    )
     res = outputs[0]
     assert res[0] == np.float32(0.02998372)
     os.remove("PETPT--GrFN.pdf")
-    os.remove('PETPT--CAG.pdf')
+    os.remove("PETPT--CAG.pdf")
 
 
 def test_petasce_creation(petasce_grfn):
     A = petasce_grfn.to_AGraph()
     CAG = petasce_grfn.CAG_to_AGraph()
     CG = petasce_grfn.FCG_to_AGraph()
-    A.draw('PETASCE--GrFN.pdf', prog='dot')
-    CAG.draw('PETASCE--CAG.pdf', prog='dot')
+    A.draw("PETASCE--GrFN.pdf", prog="dot")
+    CAG.draw("PETASCE--CAG.pdf", prog="dot")
 
     values = {
         "doy": np.array([20.0], dtype=np.float32),
@@ -107,16 +121,16 @@ def test_crop_yield_creation(crop_yield_grfn):
     assert isinstance(crop_yield_grfn, GroundedFunctionNetwork)
     G = crop_yield_grfn.to_AGraph()
     CAG = crop_yield_grfn.CAG_to_AGraph()
-    G.draw('crop_yield--GrFN.pdf', prog='dot')
-    CAG.draw('crop_yield--CAG.pdf', prog='dot')
+    G.draw("crop_yield--GrFN.pdf", prog="dot")
+    CAG.draw("crop_yield--CAG.pdf", prog="dot")
 
 
 def test_sir_simple_creation(sir_simple_grfn):
     assert isinstance(sir_simple_grfn, GroundedFunctionNetwork)
     G = sir_simple_grfn.to_AGraph()
-    G.draw('SIR-simple--GrFN.pdf', prog='dot')
+    G.draw("SIR-simple--GrFN.pdf", prog="dot")
     CAG = sir_simple_grfn.CAG_to_AGraph()
-    CAG.draw('SIR-simple--CAG.pdf', prog='dot')
+    CAG.draw("SIR-simple--CAG.pdf", prog="dot")
     # This importlib look up the lambdas file. Thus, the program must
     # maintain the files up to this level before clean up.
     lambdas = importlib.__import__(f"SIR-simple_lambdas")
@@ -130,24 +144,42 @@ def test_sir_simple_creation(sir_simple_grfn):
 def test_sir_gillespie_inline_creation(sir_gillespie_inline_grfn):
     assert isinstance(sir_gillespie_inline_grfn, GroundedFunctionNetwork)
     G = sir_gillespie_inline_grfn.to_AGraph()
-    G.draw('SIR-Gillespie_inline--GrFN.pdf', prog='dot')
+    G.draw("SIR-Gillespie_inline--GrFN.pdf", prog="dot")
     CAG = sir_gillespie_inline_grfn.CAG_to_AGraph()
-    CAG.draw('SIR-Gillespie_inline--CAG.pdf', prog='dot')
+    CAG.draw("SIR-Gillespie_inline--CAG.pdf", prog="dot")
 
 
 def test_sir_gillespie_ms_creation(sir_gillespie_ms_grfn):
     assert isinstance(sir_gillespie_ms_grfn, GroundedFunctionNetwork)
     G = sir_gillespie_ms_grfn.to_AGraph()
-    G.draw('SIR-Gillespie_ms--GrFN.pdf', prog='dot')
+    G.draw("SIR-Gillespie_ms--GrFN.pdf", prog="dot")
     CAG = sir_gillespie_ms_grfn.CAG_to_AGraph()
-    CAG.draw('SIR-Gillespie_ms--CAG.pdf', prog='dot')
+    CAG.draw("SIR-Gillespie_ms--CAG.pdf", prog="dot")
 
 
 def test_linking_graph():
-    grfn = json.load(open("tests/data/program_analysis/SIR-simple_with_groundings.json", "r"))
+    grfn = json.load(
+        open(
+            "tests/data/program_analysis/SIR-simple_with_groundings.json", "r"
+        )
+    )
     tables = linking.make_link_tables(grfn)
     linking.print_table_data(tables)
     assert len(tables.keys()) == 11
+
+
+def test_GrFN_Json_dumping(petpt_grfn):
+    PETPT_json = petpt_grfn.to_json()
+    PETPT_dict = json.loads(PETPT_json)
+    assert "nodes" in PETPT_dict
+    assert "edges" in PETPT_dict
+    assert "containers" in PETPT_dict
+    assert len(PETPT_dict["nodes"]) == 35
+
+    filepath = "tests/data/program_analysis/GrFN_JSON_TEST.json"
+    petpt_grfn.to_json_file(filepath)
+    assert os.path.isfile(filepath)
+    os.remove(filepath)
 
 
 @pytest.mark.skip("Need to update to latest JSON")
@@ -159,7 +191,7 @@ def test_petasce_torch_execution():
     N = 100
     samples = {
         "petasce::doy_0": np.random.randint(1, 100, N),
-        "petasce::meevp_0": np.where(np.random.rand(N) >= 0.5, 'A', 'W'),
+        "petasce::meevp_0": np.where(np.random.rand(N) >= 0.5, "A", "W"),
         "petasce::msalb_0": np.random.uniform(0, 1, N),
         "petasce::srad_0": np.random.uniform(1, 30, N),
         "petasce::tmax_0": np.random.uniform(-30, 60, N),


### PR DESCRIPTION
This PR adds the `to_json` and `to_json_file` methods to the GroundedFunctionNetwork class that enables outputting a GrFN in our new GrFN JSON format. Future changes to the format will be necessary once we decide upon the subtle changes that still need to be made to the GrFN JSON.