### PR TITLE
Bug fixes to get_comment.py

### DIFF
--- a/delphi/translators/for2py/get_comments.py
+++ b/delphi/translators/for2py/get_comments.py
@@ -75,8 +75,8 @@ def get_comments(src_file_name: str):
     comments = OrderedDict()
     lineno = 1
 
-    comments["$file_head"] = []
-    comments["$file_foot"] = []
+    comments["$file_head"] = None
+    comments["$file_foot"] = None
 
     _, f_ext = os.path.splitext(src_file_name)
 
@@ -85,18 +85,18 @@ def get_comments(src_file_name: str):
             if line_is_comment(line):
                 curr_comment.append(line)
             else:
-                if curr_fn is not None and comments["$file_head"] == []:
+                if comments["$file_head"] is None:
                     comments["$file_head"] = curr_comment
 
                 f_start, f_name_maybe = line_starts_subpgm(line)
                 if f_start:
                     f_name = f_name_maybe
 
-                    if prev_fn != None:
-                        comments[prev_fn]["foot"] = curr_comment
-
                     prev_fn = curr_fn
                     curr_fn = f_name
+
+                    if prev_fn is not None:
+                        comments[prev_fn]["foot"] = curr_comment
 
                     comments[curr_fn] = init_comment_map(
                         curr_comment, [], [], OrderedDict()
@@ -132,6 +132,12 @@ def get_comments(src_file_name: str):
     if curr_comment != [] and comments.get(curr_fn):
         comments[curr_fn]["foot"] = curr_comment
         comments["$file_foot"] = curr_comment
+
+    if comments["$file_head"] is None:
+        comments["$file_head"] = []
+    if comments["$file_foot"] is None:
+        comments["$file_foot"] = []
+
     return comments
 
 

--- a/tests/data/program_analysis/arrays/arrays-basic-06_GrFN.json
+++ b/tests/data/program_analysis/arrays/arrays-basic-06_GrFN.json
@@ -1,7 +1,15 @@
 {
+  "start": [
+    "@container::arrays-basic-06::@global::main"
+  ],
   "containers": [
     {
+      "name": "@container::arrays-basic-06::@global::main",
+      "source_refs": [],
+      "repeat": false,
       "arguments": [],
+      "updated": [],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -36,17 +44,19 @@
           "output": [],
           "updated": []
         }
-      ],
-      "name": "@container::arrays-basic-06::@global::main",
-      "repeat": false,
-      "return_value": [],
-      "source_refs": [],
-      "updated": []
+      ]
     },
     {
+      "name": "@container::arrays-basic-06::main::loop$0",
+      "source_refs": [],
+      "repeat": true,
       "arguments": [
         "@variable::a::-1"
       ],
+      "updated": [
+        "@variable::a::0"
+      ],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -112,20 +122,20 @@
           ],
           "updated": []
         }
-      ],
-      "name": "@container::arrays-basic-06::main::loop$0",
-      "repeat": true,
-      "return_value": [],
-      "source_refs": [],
-      "updated": [
-        "@variable::a::0"
       ]
     },
     {
+      "name": "@container::arrays-basic-06::main.loop$0::loop$1",
+      "source_refs": [],
+      "repeat": true,
       "arguments": [
         "@variable::a::-1",
         "@variable::i::-1"
       ],
+      "updated": [
+        "@variable::a::0"
+      ],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -192,21 +202,21 @@
           ],
           "updated": []
         }
-      ],
-      "name": "@container::arrays-basic-06::main.loop$0::loop$1",
-      "repeat": true,
-      "return_value": [],
-      "source_refs": [],
-      "updated": [
-        "@variable::a::0"
       ]
     },
     {
+      "name": "@container::arrays-basic-06::main.loop$0.loop$1::loop$2",
+      "source_refs": [],
+      "repeat": true,
       "arguments": [
         "@variable::a::-1",
         "@variable::i::-1",
         "@variable::j::-1"
       ],
+      "updated": [
+        "@variable::a::0"
+      ],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -274,17 +284,15 @@
           ],
           "updated": []
         }
-      ],
-      "name": "@container::arrays-basic-06::main.loop$0.loop$1::loop$2",
-      "repeat": true,
-      "return_value": [],
-      "source_refs": [],
-      "updated": [
-        "@variable::a::0"
       ]
     },
     {
+      "name": "@container::arrays-basic-06::main::loop$3",
+      "source_refs": [],
+      "repeat": true,
       "arguments": [],
+      "updated": [],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -345,15 +353,15 @@
           ],
           "updated": []
         }
-      ],
-      "name": "@container::arrays-basic-06::main::loop$3",
-      "repeat": true,
-      "return_value": [],
-      "source_refs": [],
-      "updated": []
+      ]
     },
     {
+      "name": "@container::arrays-basic-06::main.loop$3::loop$4",
+      "source_refs": [],
+      "repeat": true,
       "arguments": [],
+      "updated": [],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -405,388 +413,385 @@
           ],
           "updated": []
         }
-      ],
-      "name": "@container::arrays-basic-06::main.loop$3::loop$4",
-      "repeat": true,
-      "return_value": [],
+      ]
+    }
+  ],
+  "variables": [
+    {
+      "name": "@variable::arrays-basic-06::main::a::0",
       "source_refs": [],
-      "updated": []
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          -1,
+          6,
+          5
+        ],
+        "elem_type": "int",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::a_ijk::0",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          -1,
+          6,
+          5
+        ],
+        "elem_type": "int",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::a::-1",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          -1,
+          6,
+          5
+        ],
+        "elem_type": "int",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::i::-1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::j::-1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::a::0",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          -1,
+          6,
+          5
+        ],
+        "elem_type": "int",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::k::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::IF_0::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::EXIT::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::k::1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::a::-1",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          -1,
+          6,
+          5
+        ],
+        "elem_type": "int",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::i::-1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0::a::0",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          -1,
+          6,
+          5
+        ],
+        "elem_type": "int",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::j::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::IF_0::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::EXIT::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::j::1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0::a::-1",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          -1,
+          6,
+          5
+        ],
+        "elem_type": "int",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main::a::1",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          -1,
+          6,
+          5
+        ],
+        "elem_type": "int",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0::i::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0::IF_0::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0::EXIT::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$0::i::1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$3.loop$4::j::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$3.loop$4::IF_0::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$3.loop$4::EXIT::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$3.loop$4::j::1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$3::i::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$3::IF_0::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$3::EXIT::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::arrays-basic-06::main.loop$3::i::1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
     }
   ],
   "grounding": [],
+  "types": [],
   "source": [
     "arrays-basic-06.f"
   ],
   "source_comments": {
-    "$file_foot": [],
-    "$file_head": []
+    "$file_head": [
+      "C File: arrays-basic-06.f\n",
+      "C This program has a 3-D array with mixed explicit and implicit lower bounds.\n",
+      "C     A is a 3-D array (5x5x5) of integers with mixed explicit and implicit\n",
+      "C     lower-bounds.\n"
+    ],
+    "$file_foot": []
   },
-  "start": [
-    "@container::arrays-basic-06::@global::main"
-  ],
   "system": {
+    "name": "arrays-basic-06",
     "components": [
       {
+        "grfn_source": "./arrays-basic-06_GrFN.json",
         "code_source": [
           "tests/data/program_analysis/arrays/arrays-basic-06.f"
         ],
-        "grfn_source": "./arrays-basic-06_GrFN.json",
         "imports": []
       }
-    ],
-    "name": "arrays-basic-06"
-  },
-  "types": [],
-  "variables": [
-    {
-      "domain": {
-        "dimensions": [
-          -1,
-          6,
-          5
-        ],
-        "elem_type": "int",
-        "index": 0,
-        "mutable": false
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main::a::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          -1,
-          6,
-          5
-        ],
-        "elem_type": "int",
-        "index": 0,
-        "mutable": false
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::a_ijk::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          -1,
-          6,
-          5
-        ],
-        "elem_type": "int",
-        "index": 0,
-        "mutable": false
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::a::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::i::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::j::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          -1,
-          6,
-          5
-        ],
-        "elem_type": "int",
-        "index": 0,
-        "mutable": false
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::a::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::k::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::IF_0::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::EXIT::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1.loop$2::k::1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          -1,
-          6,
-          5
-        ],
-        "elem_type": "int",
-        "index": 0,
-        "mutable": false
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::a::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::i::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          -1,
-          6,
-          5
-        ],
-        "elem_type": "int",
-        "index": 0,
-        "mutable": false
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0::a::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::j::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::IF_0::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::EXIT::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0.loop$1::j::1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          -1,
-          6,
-          5
-        ],
-        "elem_type": "int",
-        "index": 0,
-        "mutable": false
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0::a::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          -1,
-          6,
-          5
-        ],
-        "elem_type": "int",
-        "index": 0,
-        "mutable": false
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main::a::1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0::i::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0::IF_0::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0::EXIT::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$0::i::1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$3.loop$4::j::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$3.loop$4::IF_0::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$3.loop$4::EXIT::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$3.loop$4::j::1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$3::i::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$3::IF_0::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$3::EXIT::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::arrays-basic-06::main.loop$3::i::1",
-      "source_refs": []
-    }
-  ]
+    ]
+  }
 }

--- a/tests/data/program_analysis/derived-types/derived-types-02_GrFN.json
+++ b/tests/data/program_analysis/derived-types/derived-types-02_GrFN.json
@@ -1,7 +1,249 @@
 {
+  "variables": [
+    {
+      "name": "@variable::derived-types-02::main::var::0",
+      "source_refs": [],
+      "domain": {
+        "name": "mytype",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main::x::0",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          4
+        ],
+        "elem_type": "mytype",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main::var_i::-2",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0::var_a_i::0",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          4
+        ],
+        "elem_type": "float",
+        "mutable": true
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::a_j::0",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          4
+        ],
+        "elem_type": "float",
+        "mutable": true
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::i::-1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::a::-1",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          4
+        ],
+        "elem_type": "float",
+        "mutable": true
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0::a::1",
+      "source_refs": [],
+      "domain": {
+        "index": 0,
+        "dimensions": [
+          4
+        ],
+        "elem_type": "float",
+        "mutable": true
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::j::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::IF_0::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::EXIT::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0.loop$1::j::1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0::i::-1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0::i::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0::IF_0::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0::EXIT::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$0::i::1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$2::i::-1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$2::i::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$2::IF_0::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$2::EXIT::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-02::main.loop$2::i::1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    }
+  ],
   "containers": [
     {
+      "name": "@container::derived-types-02::@global::main",
+      "source_refs": [],
+      "repeat": false,
       "arguments": [],
+      "updated": [],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -49,17 +291,17 @@
           "output": [],
           "updated": []
         }
-      ],
-      "name": "@container::derived-types-02::@global::main",
-      "repeat": false,
-      "return_value": [],
-      "source_refs": [],
-      "updated": []
+      ]
     },
     {
+      "name": "@container::derived-types-02::main::loop$0",
+      "source_refs": [],
+      "repeat": true,
       "arguments": [
         "@variable::i::-1"
       ],
+      "updated": [],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -140,18 +382,20 @@
           ],
           "updated": []
         }
-      ],
-      "name": "@container::derived-types-02::main::loop$0",
-      "repeat": true,
-      "return_value": [],
-      "source_refs": [],
-      "updated": []
+      ]
     },
     {
+      "name": "@container::derived-types-02::main.loop$0::loop$1",
+      "source_refs": [],
+      "repeat": true,
       "arguments": [
         "@variable::i::-1",
         "@variable::a::-1"
       ],
+      "updated": [
+        "@variable::a::0"
+      ],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -219,19 +463,17 @@
           ],
           "updated": []
         }
-      ],
-      "name": "@container::derived-types-02::main.loop$0::loop$1",
-      "repeat": true,
-      "return_value": [],
-      "source_refs": [],
-      "updated": [
-        "@variable::a::0"
       ]
     },
     {
+      "name": "@container::derived-types-02::main::loop$2",
+      "source_refs": [],
+      "repeat": true,
       "arguments": [
         "@variable::i::-1"
       ],
+      "updated": [],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -284,294 +526,64 @@
           ],
           "updated": []
         }
-      ],
-      "name": "@container::derived-types-02::main::loop$2",
-      "repeat": true,
-      "return_value": [],
-      "source_refs": [],
-      "updated": []
+      ]
     }
   ],
-  "grounding": [],
-  "source": [
-    "derived-types-02.f"
-  ],
-  "source_comments": {
-    "$file_foot": [],
-    "$file_head": []
-  },
   "start": [
     "@container::derived-types-02::@global::main"
   ],
-  "system": {
-    "components": [
-      {
-        "code_source": [
-          "tests/data/program_analysis/derived-types/derived-types-02.f"
-        ],
-        "grfn_source": "./derived-types-02_GrFN.json",
-        "imports": []
-      }
-    ],
-    "name": "derived-types-02"
-  },
+  "grounding": [],
   "types": [
     [
       {
+        "name": "@type::derived-types-02::@global::mytype",
+        "type": "type",
         "attributes": [
           {
             "name": "i",
             "type": "integer"
           },
           {
+            "name": "a",
+            "type": "Array",
+            "elem_type": "float",
             "dimensions": [
               4
-            ],
-            "elem_type": "float",
-            "name": "a",
-            "type": "Array"
+            ]
           }
-        ],
-        "name": "@type::derived-types-02::@global::mytype",
-        "type": "type"
+        ]
       }
     ]
   ],
-  "variables": [
-    {
-      "domain": {
-        "mutable": false,
-        "name": "mytype",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main::var::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          4
+  "source": [
+    "derived-types-02.f"
+  ],
+  "source_comments": {
+    "$file_head": [
+      "C File: derived-types-02.f\n",
+      "C Illustrates more complex derived types involving fields that\n",
+      "C are aggregates (in this case, 1-D arrays)\n",
+      "C \n",
+      "C This code is adapted from \n",
+      "C https://courses.physics.illinois.edu/phys466/sp2013/comp_info/derived.html\n",
+      "C\n",
+      "C The generated output is:\n",
+      "C  1   4.000   1.000   1.500   2.000\n",
+      "C  2   5.000   1.500   2.000   2.500\n",
+      "C  3   6.000   2.000   2.500   3.000\n"
+    ],
+    "$file_foot": []
+  },
+  "system": {
+    "name": "derived-types-02",
+    "components": [
+      {
+        "grfn_source": "./derived-types-02_GrFN.json",
+        "code_source": [
+          "tests/data/program_analysis/derived-types/derived-types-02.f"
         ],
-        "elem_type": "mytype",
-        "index": 0,
-        "mutable": false
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main::x::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main::var_i::-2",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          4
-        ],
-        "elem_type": "float",
-        "index": 0,
-        "mutable": true
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0::var_a_i::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          4
-        ],
-        "elem_type": "float",
-        "index": 0,
-        "mutable": true
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0.loop$1::a_j::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0.loop$1::i::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          4
-        ],
-        "elem_type": "float",
-        "index": 0,
-        "mutable": true
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0.loop$1::a::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "dimensions": [
-          4
-        ],
-        "elem_type": "float",
-        "index": 0,
-        "mutable": true
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0::a::1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0.loop$1::j::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0.loop$1::IF_0::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0.loop$1::EXIT::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0.loop$1::j::1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0::i::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0::i::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0::IF_0::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0::EXIT::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$0::i::1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$2::i::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$2::i::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$2::IF_0::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$2::EXIT::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-02::main.loop$2::i::1",
-      "source_refs": []
-    }
-  ]
+        "imports": []
+      }
+    ]
+  }
 }

--- a/tests/data/program_analysis/derived-types/derived-types-04_GrFN.json
+++ b/tests/data/program_analysis/derived-types/derived-types-04_GrFN.json
@@ -1,7 +1,15 @@
 {
+  "start": [
+    "@container::derived-types-04::@global::main"
+  ],
   "containers": [
     {
+      "name": "@container::derived-types-04::@global::main",
+      "source_refs": [],
+      "repeat": false,
       "arguments": [],
+      "updated": [],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -55,40 +63,67 @@
           ],
           "updated": []
         }
-      ],
-      "name": "@container::derived-types-04::@global::main",
-      "repeat": false,
-      "return_value": [],
+      ]
+    }
+  ],
+  "variables": [
+    {
+      "name": "@variable::derived-types-04::main::var::0",
       "source_refs": [],
-      "updated": []
+      "domain": {
+        "name": "mytype_123_456",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-04::main::var_x_a::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-04::main::var_y_c::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-04::main::var_x_b::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::derived-types-04::main::var_y_d::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
     }
   ],
   "grounding": [],
-  "source": [
-    "derived-types-04.f"
-  ],
-  "source_comments": {
-    "$file_foot": [],
-    "$file_head": []
-  },
-  "start": [
-    "@container::derived-types-04::@global::main"
-  ],
-  "system": {
-    "components": [
-      {
-        "code_source": [
-          "tests/data/program_analysis/derived-types/derived-types-04.f"
-        ],
-        "grfn_source": "./derived-types-04_GrFN.json",
-        "imports": []
-      }
-    ],
-    "name": "derived-types-04"
-  },
   "types": [
     [
       {
+        "name": "@type::derived-types-04::@global::mytype_123",
+        "type": "type",
         "attributes": [
           {
             "name": "ctr",
@@ -102,13 +137,13 @@
             "name": "b",
             "type": "integer"
           }
-        ],
-        "name": "@type::derived-types-04::@global::mytype_123",
-        "type": "type"
+        ]
       }
     ],
     [
       {
+        "name": "@type::derived-types-04::@global::mytype_456",
+        "type": "type",
         "attributes": [
           {
             "name": "ctr",
@@ -122,13 +157,13 @@
             "name": "d",
             "type": "integer"
           }
-        ],
-        "name": "@type::derived-types-04::@global::mytype_456",
-        "type": "type"
+        ]
       }
     ],
     [
       {
+        "name": "@type::derived-types-04::@global::mytype_123_456",
+        "type": "type",
         "attributes": [
           {
             "name": "x",
@@ -138,62 +173,33 @@
             "name": "y",
             "type": "mytype_456"
           }
-        ],
-        "name": "@type::derived-types-04::@global::mytype_123_456",
-        "type": "type"
+        ]
       }
     ]
   ],
-  "variables": [
-    {
-      "domain": {
-        "mutable": false,
-        "name": "mytype_123_456",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-04::main::var::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-04::main::var_x_a::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-04::main::var_y_c::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-04::main::var_x_b::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::derived-types-04::main::var_y_d::0",
-      "source_refs": []
-    }
-  ]
+  "source": [
+    "derived-types-04.f"
+  ],
+  "source_comments": {
+    "$file_head": [
+      "C File: derived-types-04.f\n",
+      "C This program uses a derived type whose fields are themselves derived types.\n",
+      "C The output produced by this program is:\n",
+      "C  123     12   34\n",
+      "C  456     21   45\n"
+    ],
+    "$file_foot": []
+  },
+  "system": {
+    "name": "derived-types-04",
+    "components": [
+      {
+        "grfn_source": "./derived-types-04_GrFN.json",
+        "code_source": [
+          "tests/data/program_analysis/derived-types/derived-types-04.f"
+        ],
+        "imports": []
+      }
+    ]
+  }
 }

--- a/tests/data/program_analysis/select_case/select02_GrFN.json
+++ b/tests/data/program_analysis/select_case/select02_GrFN.json
@@ -1,7 +1,15 @@
 {
+  "start": [
+    "@container::select02::@global::main"
+  ],
   "containers": [
     {
+      "name": "@container::select02::@global::main",
+      "source_refs": [],
+      "repeat": false,
       "arguments": [],
+      "updated": [],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -16,17 +24,19 @@
             "@variable::y::0"
           ]
         }
-      ],
-      "name": "@container::select02::@global::main",
-      "repeat": false,
-      "return_value": [],
-      "source_refs": [],
-      "updated": []
+      ]
     },
     {
+      "name": "@container::select02::main::loop$0",
+      "source_refs": [],
+      "repeat": true,
       "arguments": [
         "@variable::y::-1"
       ],
+      "updated": [
+        "@variable::y::7"
+      ],
+      "return_value": [],
       "body": [
         {
           "function": {
@@ -242,220 +252,213 @@
           ],
           "updated": []
         }
-      ],
-      "name": "@container::select02::main::loop$0",
-      "repeat": true,
-      "return_value": [],
-      "source_refs": [],
-      "updated": [
-        "@variable::y::7"
       ]
     }
   ],
+  "variables": [
+    {
+      "name": "@variable::select02::main.loop$0::IF_1::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::y::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::y::1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::IF_1::1",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::y::2",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::y::3",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::IF_1::2",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::y::4",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::y::5",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::IF_1::3",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::y::6",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::y::7",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::y::-1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main::y::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::inc::0",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::IF_0::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::EXIT::0",
+      "source_refs": [],
+      "domain": {
+        "name": "boolean",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    },
+    {
+      "name": "@variable::select02::main.loop$0::inc::1",
+      "source_refs": [],
+      "domain": {
+        "name": "integer",
+        "type": "type",
+        "mutable": false
+      },
+      "domain_constraint": "(and (> v -infty) (< v infty)))"
+    }
+  ],
   "grounding": [],
+  "types": [],
   "source": [
     "select02.f"
   ],
   "source_comments": {
-    "$file_foot": [],
-    "$file_head": []
+    "$file_head": [
+      "C FORTRAN test file to test CASE constructs\n",
+      "C This file tests an integer with various types of comparisons\n"
+    ],
+    "$file_foot": []
   },
-  "start": [
-    "@container::select02::@global::main"
-  ],
   "system": {
+    "name": "select02",
     "components": [
       {
+        "grfn_source": "./select02_GrFN.json",
         "code_source": [
           "tests/data/program_analysis/select_case/select02.f"
         ],
-        "grfn_source": "./select02_GrFN.json",
         "imports": []
       }
-    ],
-    "name": "select02"
-  },
-  "types": [],
-  "variables": [
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::IF_1::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::y::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::y::1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::IF_1::1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::y::2",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::y::3",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::IF_1::2",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::y::4",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::y::5",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::IF_1::3",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::y::6",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::y::7",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::y::-1",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main::y::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::inc::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::IF_0::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "boolean",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::EXIT::0",
-      "source_refs": []
-    },
-    {
-      "domain": {
-        "mutable": false,
-        "name": "integer",
-        "type": "type"
-      },
-      "domain_constraint": "(and (> v -infty) (< v infty)))",
-      "name": "@variable::select02::main.loop$0::inc::1",
-      "source_refs": []
-    }
-  ]
+    ]
+  }
 }


### PR DESCRIPTION
Addressing comments from @pauldhein in slack: 

During the text reading meeting yesterday it became apparent that there is a bug in the part of the PA pipeline that extracts head/neck/foot source comments and associates them with the proper subroutine or file locations. The bug seems to be a miss-association when there are multiple subroutines/functions present in a single file.
In addition it seems that we need to make a choice about how to represent block comments when there is no clear distinction between a file_head block comment and the head block comment for the first subroutine. In this case, I would like to duplicate the initial block comment so that it is extracted as the block comment for the file head and the head block comment for the first subroutine. I would like to have a similar pattern of duplication done for the foot block comment of a Fortran file. Does this make sense?
I wanted to make these changes on my own, but I am having trouble with finding time to make the changes. Can someone on the PA team take some time to review this issues above and make the necessary changes?
Attached is the PETPNO.for source code that includes source comments for PETPNO , VSPAT, and VSLOP. I have also attached the output _AIR.json I get when running scripts/f2grfn_standalone.py on the Fortran file. You can verify the bug I have described above using the source_comments portion of the attached _AIR.json. If you wish to re-run the script with the same version of PETPNO.for, then please checkout the dssat_pet branch of the delphi repository.