### PR TITLE
Fix for Travis CI timeout issue. DEFAULT_N_SAMPLES has been removed, …

### DIFF
--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -17,8 +17,6 @@
 
 const double tuning_param = 1.0;
 
-const size_t DEFAULT_N_SAMPLES = 1000;
-
 enum InitialBeta { ZERO, ONE, HALF, MEAN, RANDOM };
 
 typedef std::unordered_map<std::string, std::vector<double>>
@@ -127,6 +125,7 @@ class AnalysisGraph {
 
   std::mt19937 rand_num_generator;
 
+
   // Uniform distribution used by the MCMC sampler
   std::uniform_real_distribution<double> uni_dist;
 
@@ -136,6 +135,9 @@ class AnalysisGraph {
   // Uniform discrete distribution used by the MCMC sampler
   // to perturb the initial latent state
   std::uniform_int_distribution<int> uni_disc_dist;
+
+  // Sampling resolution
+  size_t res;
 
   /*
    ============================================================================
@@ -941,8 +943,12 @@ class AnalysisGraph {
   std::string to_json_string(int indent = 0);
   bool data_heuristic = false;
 
-  // Sampling resolution. Default is 200
-  int res = DEFAULT_N_SAMPLES;
+  // Set the sampling resolution.
+  void set_res(size_t res);
+
+  // Get the sampling resolution.
+  size_t get_res();
+
 
   /*
    ============================================================================
@@ -1006,11 +1012,11 @@ class AnalysisGraph {
 
   /** Construct an AnalysisGraph object from a JSON string exported by CauseMos.
    */
-  static AnalysisGraph from_causemos_json_string(std::string json_string);
+  static AnalysisGraph from_causemos_json_string(std::string json_string, size_t res);
 
   /** Construct an AnalysisGraph object from a file containing JSON data from
    * CauseMos. */
-  static AnalysisGraph from_causemos_json_file(std::string filename);
+  static AnalysisGraph from_causemos_json_file(std::string filename, size_t res);
 
   /**
    * Generate the response for the create model request from the HMI.

--- a/lib/DelphiPython.cpp
+++ b/lib/DelphiPython.cpp
@@ -25,7 +25,6 @@ PYBIND11_MODULE(DelphiPython, m) {
       .def("from_json_string", &AnalysisGraph::from_json_string)
       .def("generate_create_model_response", &AnalysisGraph::generate_create_model_response)
       .def_readwrite("data_heuristic", &AnalysisGraph::data_heuristic)
-      .def_readwrite("res", &AnalysisGraph::res)
       .def_property("s0",
                     &AnalysisGraph::get_initial_latent_state,
                     &AnalysisGraph::set_initial_latent_state)
@@ -46,6 +45,7 @@ PYBIND11_MODULE(DelphiPython, m) {
       .def("__getitem__", [](AnalysisGraph& G, string name) { return G[name]; })
       .def("__getitem__",
            [](AnalysisGraph& G, int node_index) { return G[node_index]; })
+      .def("get_res", &AnalysisGraph::get_res)
       .def("get_subgraph_for_concept",
            &AnalysisGraph::get_subgraph_for_concept,
            "concept"_a,

--- a/lib/causemos_integration.cpp
+++ b/lib/causemos_integration.cpp
@@ -581,16 +581,18 @@ void AnalysisGraph::from_causemos_json_dict(const nlohmann::json &json_data) {
   this->construct_theta_pdfs();
 }
 
-AnalysisGraph AnalysisGraph::from_causemos_json_string(string json_string) {
+AnalysisGraph AnalysisGraph::from_causemos_json_string(string json_string, size_t res) {
   AnalysisGraph G;
+  G.set_res(res);
 
   auto json_data = nlohmann::json::parse(json_string);
   G.from_causemos_json_dict(json_data);
   return G;
 }
 
-AnalysisGraph AnalysisGraph::from_causemos_json_file(string filename) {
+AnalysisGraph AnalysisGraph::from_causemos_json_file(string filename, size_t res) {
   AnalysisGraph G;
+  G.set_res(res);
 
   auto json_data = load_json(filename);
   G.from_causemos_json_dict(json_data);
@@ -613,11 +615,10 @@ string AnalysisGraph::generate_create_model_response() {
     vector<double> all_weights = {};
 
     for (auto e : this->edges()) {
-        int n_samples = DEFAULT_N_SAMPLES;
 
         // TODO: This variable is not used
         vector<double> sampled_thetas = this->edge(e).kde.resample(
-                n_samples, this->rand_num_generator, this->uni_dist, this->norm_dist);
+                this->res, this->rand_num_generator, this->uni_dist, this->norm_dist);
         double weight = abs(median(this->edge(e).kde.dataset));
         all_weights.push_back(weight);
 

--- a/lib/parameter_initialization.cpp
+++ b/lib/parameter_initialization.cpp
@@ -206,7 +206,8 @@ AdjectiveResponseMap construct_adjective_response_map(
     mt19937 gen,
     uniform_real_distribution<double>& uni_dist,
     normal_distribution<double>& norm_dist,
-    size_t n_kernels = DEFAULT_N_SAMPLES) {
+    size_t n_kernels
+    ) {
   sqlite3* db = nullptr;
   int rc = sqlite3_open(getenv("DELPHI_DB"), &db);
 
@@ -249,7 +250,7 @@ void AnalysisGraph::construct_theta_pdfs() {
   double sigma_Y = 1.0;
   AdjectiveResponseMap adjective_response_map =
       construct_adjective_response_map(
-          this->rand_num_generator, this->uni_dist, this->norm_dist);
+          this->rand_num_generator, this->uni_dist, this->norm_dist, this->res);
   vector<double> marginalized_responses;
   for (auto [adjective, responses] : adjective_response_map) {
     for (auto response : responses) {
@@ -258,7 +259,7 @@ void AnalysisGraph::construct_theta_pdfs() {
   }
 
   marginalized_responses = KDE(marginalized_responses)
-                               .resample(DEFAULT_N_SAMPLES,
+                               .resample(this->res,
                                          this->rand_num_generator,
                                          this->uni_dist,
                                          this->norm_dist);

--- a/lib/prediction.cpp
+++ b/lib/prediction.cpp
@@ -2,6 +2,7 @@
 #include <range/v3/all.hpp>
 #include <unsupported/Eigen/MatrixFunctions>
 #include <boost/range/adaptors.hpp>
+#include <tqdm.hpp>
 
 using namespace std;
 using Eigen::VectorXd, Eigen::MatrixXd;
@@ -25,7 +26,7 @@ void AnalysisGraph::generate_latent_state_sequences(
       this->res,
       vector<VectorXd>(this->pred_timesteps, VectorXd(this->num_vertices() * 2)));
 
-  for (int samp = 0; samp < this->res; samp++) {
+  for (int samp : tq::trange(this->res)) {
       // The sampled transition matrices would be either of matrix exponential
       // (continuous) version or discretized version depending on whether the
       // matrix exponential (continuous) version or the discretized transition

--- a/lib/sampling.cpp
+++ b/lib/sampling.cpp
@@ -262,3 +262,11 @@ void AnalysisGraph::set_default_initial_state() {
     this->s0(i) = 1.0;
   }
 }
+
+void AnalysisGraph::set_res(size_t res) {
+    this->res = res;
+}
+
+size_t AnalysisGraph::get_res() {
+    return this->res;
+}

--- a/lib/train_model.cpp
+++ b/lib/train_model.cpp
@@ -39,10 +39,12 @@ void AnalysisGraph::train_model(int start_year,
 
       this->initialize_parameters(res, initial_beta, use_heuristic, use_continuous);
 
+      cout << "Burning in..." << endl;
       for (int i : trange(burn)) {
           this->sample_from_posterior();
       }
 
+      cout << "Sampling from posterior" << endl;
       for (int i : trange(this->res)) {
           this->sample_from_posterior();
           this->transition_matrix_collection[i] = this->A_original;


### PR DESCRIPTION
…and the number of samples is controlled by the 'res' property of the AnalysisGraph class, which is set during construction time (via the static 'constructor' methods). In the CauseMos-Delphi REST API, the number of samples can be set by the DELPHI_N_SAMPLES environment variable, unless the environment variable 'CI' is set to true, in which case the number of samples is automatically set to a low value (5)