### PR TITLE
Delphi causemos bug fix 1

### DIFF
--- a/apps/create_model.cpp
+++ b/apps/create_model.cpp
@@ -37,7 +37,9 @@ int main(int argc, char* argv[]) {
 };
 
 
-    AnalysisGraph G = AnalysisGraph::from_causemos_json_file("../tests/data/delphi/causemos_create-model.json", 4);
+    AnalysisGraph G = AnalysisGraph::from_causemos_json_file("../tests/data/delphi/causemos_create-model_nodata.json", 4);
+
+    return(0);
 
     string result = G.serialize_to_json_string(false);
 

--- a/apps/sandbox_tester.cpp
+++ b/apps/sandbox_tester.cpp
@@ -2,7 +2,6 @@
 
 #include "AnalysisGraph.hpp"
 #include <boost/program_options.hpp>
-#include "dbg.h"
 #include <iostream>
 #include <fstream>
 

--- a/delphi/evaluation.py
+++ b/delphi/evaluation.py
@@ -439,6 +439,9 @@ def mean_pred_to_df(
         # When I do a similar call at the Python command line, the warning does
         # not appear.
         # Could not figure out how to make this warning go away.
+        #
+        # Bug: When all the values are the same, stats.bayes_mvs returns NaN as
+        # the mean.
         pred_stats = np.apply_along_axis(stats.bayes_mvs, 1, pred_raw.T, ci)[
             :, 0
         ]

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -856,6 +856,9 @@ class AnalysisGraph {
    */
   void generate_observed_state_sequences();
 
+  std::vector<std::vector<double>>
+  generate_observed_state(Eigen::VectorXd latent_state);
+
   /**
    * Format the prediction result into a format Python callers favor.
    *

--- a/lib/parameter_initialization.cpp
+++ b/lib/parameter_initialization.cpp
@@ -224,7 +224,7 @@ AdjectiveResponseMap construct_adjective_response_map(
     string adjective =
         string(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
     double response = sqlite3_column_double(stmt, 6);
-    if (in(adjective_response_map, adjective)) {
+    if (!in(adjective_response_map, adjective)) {
       adjective_response_map[adjective] = {response};
     }
     else {

--- a/lib/prediction.cpp
+++ b/lib/prediction.cpp
@@ -74,7 +74,7 @@ void AnalysisGraph::generate_latent_state_sequences(
       if (this->clamp_at_derivative) {
           // To clamp a latent state value to x_c at prediction step 1 via
           // clamping the derivative, we have to perturb the derivative at
-          // prediction step 0, before evolving it to time prediction step 1.
+          // prediction step 0, before evolving it to prediction time step 1.
           // So we have to look one time step ahead whether we have to clamp
           // at 1.
           //
@@ -339,7 +339,7 @@ void AnalysisGraph::run_model(int start_year,
        start_month <= this->training_range.first.second)) {
     print("The initial prediction date can't be before the "
          "initial training date. Defaulting initial prediction date "
-         "to initial training date.");
+         "to initial training date + 1 month.");
     start_month = this->training_range.first.second + 1;
     if (start_month == 13) {
         start_year = this->training_range.first.first + 1;
@@ -396,6 +396,11 @@ void AnalysisGraph::run_model(int start_year,
   //       returning results, we have to remove the predictions at the 0th
   //       index of each predicted observed state sequence.
   //       Adding that additional time step.
+  // t     = Requested prediction start time step
+  //       = pred_init_timestep
+  // t - 1 = Prediction start time step
+  //       = pred_init_timestep - 1
+  pred_init_timestep--;
   this->pred_timesteps++;
 
   this->generate_latent_state_sequences(pred_init_timestep);

--- a/lib/prediction.cpp
+++ b/lib/prediction.cpp
@@ -281,10 +281,32 @@ void AnalysisGraph::generate_observed_state_sequences() {
 
     this->predicted_observed_state_sequences[samp] =
         sample | transform([this](VectorXd latent_state) {
-          return this->sample_observed_state(latent_state);
+          return this->generate_observed_state(latent_state);
         }) |
         to<vector>();
   }
+}
+
+vector<vector<double>>
+AnalysisGraph::generate_observed_state(VectorXd latent_state) {
+  using rs::to, rs::views::transform;
+
+  int num_verts = this->num_vertices();
+
+  vector<vector<double>> observed_state(num_verts);
+
+  for (int v = 0; v < num_verts; v++) {
+    vector<Indicator>& indicators = (*this)[v].indicators;
+
+    observed_state[v] = vector<double>(indicators.size());
+
+    observed_state[v] = indicators | transform([&](Indicator ind) {
+                          return ind.mean * latent_state[2 * v];
+                        }) |
+                        to<vector>();
+  }
+
+  return observed_state;
 }
 
 FormattedPredictionResult AnalysisGraph::format_prediction_result() {


### PR DESCRIPTION
Fixed some bugs

1. causemose create-model can now create a model without providing any training data. But such a model cannot be trained.

2. Fixed a constraint application time step off error

3. Fixed generating predicted observations.

4. Fixed constructing theta pdfs