### PR TITLE
Resolving multiple uses of the "res" variable.

### DIFF
--- a/apps/delphi_rest_api.cpp
+++ b/apps/delphi_rest_api.cpp
@@ -468,7 +468,7 @@ int main(int argc, const char* argv[]) {
              Adarsh
             */
             size_t kde_kernels = 1000;
-            int sampling_resolution = 1000, burn = 10000;
+            int sampling_resolution = 200, burn = 10000;
             if (getenv("CI")) {
 	        cout << "CI mode detected" << endl;
                 // When running in a continuous integration run, we set the
@@ -487,7 +487,7 @@ int main(int argc, const char* argv[]) {
             }
 
             AnalysisGraph G;
-            G.set_res(kde_kernels);
+            G.set_n_kde_kernels(kde_kernels);
             G.from_causemos_json_dict(json_data, 0, 0);
 
             sqlite3DB->insert_into_delphimodel(

--- a/delphi/apps/rest_api/api.py
+++ b/delphi/apps/rest_api/api.py
@@ -53,7 +53,7 @@ def createNewModel():
         # TODO - we might want to set the default sampling resolution with some
         # kind of heuristic, based on the number of nodes and edges. - Adarsh
         kde_kernels = 1000
-        sampling_resolution = 1000
+        sampling_resolution = 200
         burn = 10000
 
     data = json.loads(request.data)

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -207,6 +207,9 @@ class AnalysisGraph {
   // Sampling resolution
   size_t res;
 
+  // Number of KDE kernels
+  size_t n_kde_kernels = 1000;
+
   /*
    ============================================================================
    Meta Data Structures
@@ -1026,6 +1029,10 @@ class AnalysisGraph {
 
   // Set the sampling resolution.
   void set_res(size_t res);
+
+  // Set the number of KDE kernels.
+  void set_n_kde_kernels(size_t kde_kernels)
+      {this->n_kde_kernels = kde_kernels;};
 
   // Get the sampling resolution.
   size_t get_res();

--- a/lib/causemos_integration.cpp
+++ b/lib/causemos_integration.cpp
@@ -822,7 +822,7 @@ AnalysisGraph AnalysisGraph::from_causemos_json_string(string json_string,
                                                        int kde_kernels
                                                        ) {
   AnalysisGraph G;
-  G.set_res(kde_kernels);
+  G.n_kde_kernels = kde_kernels;
 
   auto json_data = nlohmann::json::parse(json_string);
   G.from_causemos_json_dict(json_data, belief_score_cutoff, grounding_score_cutoff);
@@ -835,7 +835,7 @@ AnalysisGraph AnalysisGraph::from_causemos_json_file(string filename,
                                                      int kde_kernels
                                                      ) {
   AnalysisGraph G;
-  G.set_res(kde_kernels);
+  G.n_kde_kernels = kde_kernels;
 
   auto json_data = load_json(filename);
   G.from_causemos_json_dict(json_data, belief_score_cutoff, grounding_score_cutoff);

--- a/lib/constructors.cpp
+++ b/lib/constructors.cpp
@@ -122,7 +122,7 @@ AnalysisGraph::from_causal_fragments_with_data(pair<vector<CausalFragment>,
                                                int kde_kernels) {
   AnalysisGraph G = from_causal_fragments(cag_ind_data.first);
 
-  G.set_res(kde_kernels);
+  G.n_kde_kernels = kde_kernels;
 
   G.observed_state_sequence.clear();
   G.n_timesteps = 0;
@@ -251,6 +251,7 @@ AnalysisGraph::AnalysisGraph(const AnalysisGraph& rhs) {
   this->id = rhs.id;
   this->data_heuristic = rhs.data_heuristic;
   this->res = rhs.res;
+  this->n_kde_kernels = rhs.n_kde_kernels;
 
   for_each(rhs.node_indices(), [&](int v) {
     Node node_rhs = rhs.graph[v];

--- a/lib/parameter_initialization.cpp
+++ b/lib/parameter_initialization.cpp
@@ -410,7 +410,7 @@ void AnalysisGraph::construct_theta_pdfs() {
   double sigma_Y = 1.0;
   AdjectiveResponseMap adjective_response_map =
       this->construct_adjective_response_map(
-          this->rand_num_generator, this->uni_dist, this->norm_dist, this->res);
+          this->rand_num_generator, this->uni_dist, this->norm_dist, this->n_kde_kernels);
   vector<double> marginalized_responses;
   for (auto [adjective, responses] : adjective_response_map) {
     for (auto response : responses) {
@@ -419,7 +419,7 @@ void AnalysisGraph::construct_theta_pdfs() {
   }
 
   marginalized_responses = KDE(marginalized_responses)
-                               .resample(this->res,
+                               .resample(this->n_kde_kernels,
                                          this->rand_num_generator,
                                          this->uni_dist,
                                          this->norm_dist);

--- a/lib/synthetic_data.cpp
+++ b/lib/synthetic_data.cpp
@@ -105,7 +105,7 @@ void AnalysisGraph::initialize_random_CAG(unsigned int num_obs,
                                           bool use_continuous) {
   this->initialize_random_number_generator();
   this->set_default_initial_state(initial_derivative);
-  this->set_res(kde_kernels);
+  this->n_kde_kernels = kde_kernels;
   this->construct_theta_pdfs();
   this->init_betas_to(initial_beta);
   this->pred_timesteps = num_obs + 1;


### PR DESCRIPTION
The member variable "res" was used for the sampling resolution and the
number of KDE kernels. Therefore, Delphi ended up using the same value
for both.

Separated these usages by introducing a new member variable
"n_kde_kernels". The resolution was done in the least code change way
and hence not the most elegant approach. Ideally, n_kde_kernels should
be an argument for the AnalysisGraph::run_train_model() method.

Also, reduced the sampling resolution to 200 (the value used earlier) from 1000.