### PR TITLE
Dockerfile support for delphi_rest_api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV VIRTUAL_ENV=/venv
 ENV DELPHI_DB=/delphi/data/delphi.db
 ENV MODEL_FILES=/delphi/data/source_model_files
 
-
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
       build-essential \
@@ -28,15 +27,31 @@ RUN apt-get update \
       libeigen3-dev \
       pybind11-dev \
       libfmt-dev \
-      librange-v3-dev
+      librange-v3-dev \
+      nlohmann-json3-dev
 
-RUN apt-get -y install nlohmann-json3-dev
+# build served from source
+RUN curl -LO https://github.com/meltwater/served/archive/refs/tags/v1.6.0.tar.gz; \
+      tar -xzf v1.6.0.tar.gz; \
+      cd served-1.6.0; \
+           mkdir build; \
+           cd build; \
+           cmake ..; \
+           make -j `nproc` install; \
+      cd ..
 
 COPY . /delphi
 WORKDIR /delphi
 
 RUN python3 -m venv $VIRTUAL_ENV
-
 RUN mkdir -p data && curl http://vanga.sista.arizona.edu/delphi_data/delphi.db -o data/delphi.db
-RUN . $VIRTUAL_ENV/bin/activate && pip install wheel && pip install -e .
-CMD delphi_rest_api
+RUN . $VIRTUAL_ENV/bin/activate && pip install wheel && pip install pyparsing==2.4.7 && pip install -e .
+
+# build delphi_rest_api
+RUN make clean; \
+      cd build; \
+      cmake ..; \
+      make -j `nproc`; 
+
+# start the delphi_rest_api
+ENTRYPOINT ./build/delphi_rest_api -h host.docker.internal -p 1883

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,11 @@ RUN apt-get update \
       git \
       tar \
       wget \
-      python3-dev \
-      python3-venv \
       doxygen \
       graphviz \
       libgraphviz-dev \
       libsqlite3-dev \
       libeigen3-dev \
-      pybind11-dev \
       libfmt-dev \
       librange-v3-dev \
       nlohmann-json3-dev
@@ -43,9 +40,7 @@ RUN curl -LO https://github.com/meltwater/served/archive/refs/tags/v1.6.0.tar.gz
 COPY . /delphi
 WORKDIR /delphi
 
-RUN python3 -m venv $VIRTUAL_ENV
 RUN mkdir -p data && curl http://vanga.sista.arizona.edu/delphi_data/delphi.db -o data/delphi.db
-RUN . $VIRTUAL_ENV/bin/activate && pip install wheel && pip install pyparsing==2.4.7 && pip install -e .
 
 # build delphi_rest_api
 RUN make clean; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ RUN make clean; \
       make -j `nproc`; 
 
 # start the delphi_rest_api
-ENTRYPOINT ./build/delphi_rest_api -h host.docker.internal -p 1883
+ENTRYPOINT ./build/delphi_rest_api 


### PR DESCRIPTION
The ~/delphi/Dockerfile will now build and run the delphi_rest_api application.
CauseMos API version 3.0.0 is implemented.