### PR TITLE
Implemented an infrastructure to freeze edge weights and take frozen edges out of sampling.

### DIFF
--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -217,9 +217,11 @@ class AnalysisGraph {
   // Normal distribution used to perturb β
   std::normal_distribution<double> norm_dist;
 
-  // Uniform discrete distribution used by the MCMC sampler
+  // Uniform discrete distributions used by the MCMC sampler
   // to perturb the initial latent state
   std::uniform_int_distribution<int> uni_disc_dist;
+  // to sample an edge
+  std::uniform_int_distribution<int> uni_disc_dist_edge;
 
   // Sampling resolution
   size_t res;
@@ -299,6 +301,7 @@ class AnalysisGraph {
 
   std::unordered_map<int, std::function<double(unsigned int, double)>> external_concepts;
   std::vector<unsigned int> concept_sample_pool;
+  std::vector<EdgeDescriptor> edge_sample_pool;
 
   double t = 0.0;
   double delta_t = 1.0;

--- a/lib/Edge.hpp
+++ b/lib/Edge.hpp
@@ -61,6 +61,7 @@ class Edge {
   // θ = atan(1) = Π/4
   // β = tan(atan(1)) = 1
   double theta = std::atan(1);
+  bool frozen = false;
 
   public:
   std::string name;
@@ -72,17 +73,34 @@ class Edge {
   // The current log(p(θ))
   double logpdf_theta = 0;
 
+  void freeze() {
+      this->frozen = true;
+  }
+
+  void unfreeze() {
+      this->frozen = false;
+  }
+
+  bool is_frozen() {
+      return this->frozen;
+  }
+
   void set_theta(double theta) {
-    if (0 <= theta && theta <= M_PI) {
-      this->theta = theta;
-    } else if (-M_PI <= theta && theta < 0) {
-      this->theta = M_PI + theta;
-    } else if (M_PI < theta && theta <= 2 * M_PI) {
-      this->theta = theta - M_PI;
-    } else {
-      std::cout << "\n\n\t**********ERROR: Edge.hpp - theta outside range coded for processing!!**********\n\n";
-      std::cout << theta << std::endl;
-    }
+      if (!this->frozen) {
+          if (0 <= theta && theta <= M_PI) {
+              this->theta = theta;
+          }
+          else if (-M_PI <= theta && theta < 0) {
+              this->theta = M_PI + theta;
+          }
+          else if (M_PI < theta && theta <= 2 * M_PI) {
+              this->theta = theta - M_PI;
+          }
+          else {
+              std::cout << "\n\n\t**********ERROR: Edge.hpp - theta outside range coded for processing!!**********\n\n";
+              std::cout << theta << std::endl;
+          }
+      }
   }
 
    double get_theta() const {

--- a/lib/parameter_initialization.cpp
+++ b/lib/parameter_initialization.cpp
@@ -23,6 +23,8 @@ void AnalysisGraph::initialize_parameters(int res,
     this->initialize_random_number_generator();
     this->uni_disc_dist = uniform_int_distribution<int>
                                 (0, this->concept_sample_pool.size() - 1);
+    this->uni_disc_dist_edge = uniform_int_distribution<int>
+                                (0, this->edge_sample_pool.size() - 1);
 
     this->res = res;
     this->continuous = use_continuous;

--- a/lib/printing.cpp
+++ b/lib/printing.cpp
@@ -33,7 +33,10 @@ void AnalysisGraph::print_nodes() {
 void AnalysisGraph::print_edges() {
   for_each(edges(), [&](auto e) {
     cout << "(" << (*this)[boost::source(e, this->graph)].name << ", "
-         << (*this)[boost::target(e, this->graph)].name << ")" << endl;
+         << (*this)[boost::target(e, this->graph)].name << ")" << " - "
+         << (this->graph[e].is_frozen()
+                        ? "Frozen at " + to_string(this->graph[e].get_theta())
+                        : "Free") << endl;
   });
 }
 

--- a/lib/profiler.cpp
+++ b/lib/profiler.cpp
@@ -23,6 +23,13 @@ void AnalysisGraph::initialize_profiler(int res,
       }
     }
 
+    this->edge_sample_pool.clear();
+    for (EdgeDescriptor ed : this->edges()) {
+        if (!this->graph[ed].is_frozen()) {
+            this->edge_sample_pool.push_back(ed);
+        }
+    }
+
     this->n_kde_kernels = kde_kernels;
 
     this->initialize_parameters(res, initial_beta, initial_derivative,

--- a/lib/sampling.cpp
+++ b/lib/sampling.cpp
@@ -258,23 +258,31 @@ void AnalysisGraph::sample_from_posterior() {
 
 void AnalysisGraph::sample_from_proposal() {
   // Flip a coin and decide whether to perturb a θ or a derivative
-  this->coin_flip = this->uni_dist(this->rand_num_generator);
+  if (this->edge_sample_pool.empty()) {
+      // All edge weights are frozen. Always sample a concept.
+      this->coin_flip = this->coin_flip_thresh;
+  } else {
+      this->coin_flip = this->uni_dist(this->rand_num_generator);
+  }
   this->generated_concept = -1;
 
   if (this->coin_flip < this->coin_flip_thresh) {
     // Randomly pick an edge ≡ θ
-    boost::iterator_range edge_it = this->edges();
-
-    vector<EdgeDescriptor> e(1);
-    sample(
-        edge_it.begin(), edge_it.end(), e.begin(), 1, this->rand_num_generator);
+//    boost::iterator_range edge_it = this->edges();
+//
+//    vector<EdgeDescriptor> e(1);
+//    sample(
+//        edge_it.begin(), edge_it.end(), e.begin(), 1, this->rand_num_generator);
+    EdgeDescriptor ed = this->edge_sample_pool[this->uni_disc_dist_edge(this->rand_num_generator)];
 
     // Remember the previous θ and logpdf(θ)
-    this->previous_theta = make_tuple(e[0], this->graph[e[0]].get_theta(), this->graph[e[0]].logpdf_theta);
+//    this->previous_theta = make_tuple(e[0], this->graph[e[0]].get_theta(), this->graph[e[0]].logpdf_theta);
+    this->previous_theta = make_tuple(ed, this->graph[ed].get_theta(), this->graph[ed].logpdf_theta);
 
     // Perturb the θ and compute the new logpdf(θ)
     // TODO: Check whether this perturbation is accurate
-    this->graph[e[0]].set_theta(this->graph[e[0]].get_theta() + this->norm_dist(this->rand_num_generator));
+//    this->graph[e[0]].set_theta(this->graph[e[0]].get_theta() + this->norm_dist(this->rand_num_generator));
+    this->graph[ed].set_theta(this->graph[ed].get_theta() + this->norm_dist(this->rand_num_generator));
     {
       #ifdef TIME
         this->mcmc_part_duration.second.clear();
@@ -283,7 +291,8 @@ void AnalysisGraph::sample_from_proposal() {
         this->mcmc_part_duration.second.push_back(this->num_edges());
         Timer t_part = Timer("KDE", this->mcmc_part_duration);
       #endif
-      this->graph[e[0]].compute_logpdf_theta();
+//      this->graph[e[0]].compute_logpdf_theta();
+      this->graph[ed].compute_logpdf_theta();
     }
     #ifdef TIME
       this->mcmc_part_duration.second.push_back(10);
@@ -299,7 +308,8 @@ void AnalysisGraph::sample_from_proposal() {
         this->mcmc_part_duration.second.push_back(this->num_edges());
         Timer t_part = Timer("UPTM", this->mcmc_part_duration);
       #endif
-      this->update_transition_matrix_cells(e[0]);
+//      this->update_transition_matrix_cells(e[0]);
+      this->update_transition_matrix_cells(ed);
     }
     #ifdef TIME
       this->mcmc_part_duration.second.push_back(12);

--- a/lib/train_model.cpp
+++ b/lib/train_model.cpp
@@ -189,6 +189,13 @@ void AnalysisGraph::run_train_model(int res,
       }
     }
 
+    this->edge_sample_pool.clear();
+    for (EdgeDescriptor ed : this->edges()) {
+        if (!this->graph[ed].is_frozen()) {
+            this->edge_sample_pool.push_back(ed);
+        }
+    }
+
     this->initialize_parameters(res, initial_beta, initial_derivative,
                                 use_heuristic, use_continuous);
 


### PR DESCRIPTION
To freeze an edge:
1. Set edge theta by calling set_theta(theta) on the edge to be frozen.
2. Call freeze() on an edge to freeze if.
3. For debugging purposes call print_edges() on the AnalysisGraph object
to print a list of edges.

Call unfreeze() on an edge to unfreeze it if needed.