### PR TITLE
1 delphi edit edge weights mw

### DIFF
--- a/apps/create_model.cpp
+++ b/apps/create_model.cpp
@@ -474,13 +474,31 @@ int main(int argc, char* argv[]) {
         {{"small", 1, "n1"}, {"large", -1, "n2"}},
   };
 
+  cout << "Creating model\n";
+  AnalysisGraph G = AnalysisGraph::from_causemos_json_file(
+    "../tests/data/delphi/create_model_rain--temperature--yield.json", 0);
 
-    cout << "Creating model\n";
-    AnalysisGraph G = AnalysisGraph::from_causemos_json_file(
-      "../tests/data/delphi/create_model_rain--temperature--yield.json", 0);
-    G.train_model();
-    FormattedProjectionResult proj = G.run_causemos_projection_experiment_from_json_file(
-        "../tests/data/delphi/experiments_rain--temperature--yield.json");
+  unsigned short status = G.freeze_edge_weight(
+                            "wm/concept/environment/meteorology/precipitation",
+                            "wm/concept/agriculture/crop_produce",
+                            0.5, 1);
+  if (status == 0) {
+        G.print_edges();
+  }
+  else {
+      cout << "Error: " << status << endl;
+  }
+
+  string frozen = G.serialize_to_json_string(false);
+  AnalysisGraph G2 = AnalysisGraph::deserialize_from_json_string(frozen, false);
+  G2.print_edges();
+
+  G2.set_n_kde_kernels(100);
+  G2.run_train_model(10, 10);
+  cout << nlohmann::json::parse(G2.generate_create_model_response()).dump(2);
+  FormattedProjectionResult proj;
+  proj = G2.run_causemos_projection_experiment_from_json_file(
+      "../tests/data/delphi/experiments_rain--temperature--yield.json");
   return(0);
 
   test_simple_path_construction();

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -1215,7 +1215,7 @@ class AnalysisGraph {
    * @return true if freezing the edge is successful
    *         false otherwise
    */
-  bool freeze_edge_weight(std::string source, std::string target,
+  unsigned short freeze_edge_weight(std::string source, std::string target,
                           double scaled_weight, int polarity);
 
   /*

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -1198,6 +1198,26 @@ class AnalysisGraph {
   FormattedProjectionResult
   run_causemos_projection_experiment_from_json_file(std::string filename);
 
+
+    /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                      edit-weights
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+  /**
+   *
+   * @param source Source concept name
+   * @param target Target concept name
+   * @param scaled_weight A value in the range [-1, 1]. Sign of the value
+   *               indicate the polarity. Delphi edge weights are angles
+   *               in the range [0, π]. Values in the range ]0, π/2[ represent
+   *               positive polarities and values in the range ]π/2, π[
+   *               represent negative polarities.
+   * @return true if freezing the edge is successful
+   *         false otherwise
+   */
+  bool freeze_edge_weight(std::string source, std::string target,
+                          double scaled_weight);
+
   /*
    ============================================================================
    Public: Model serialization (in serialize.cpp)

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -1212,8 +1212,11 @@ class AnalysisGraph {
    *               represents positive polarities and values in the range
    *               ]π/2, π[ represents negative polarities.
    * @param polarity Polarity of the edge. Should be either 1 or -1.
-   * @return true if freezing the edge is successful
-   *         false otherwise
+   * @return 0 freezing the edge is successful
+   *         1 scaled_weight outside accepted range
+   *         2 Source concept does not exist
+   *         4 Target concept does not exist
+   *         8 Edge does not exist
    */
   unsigned short freeze_edge_weight(std::string source, std::string target,
                           double scaled_weight, int polarity);

--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -1207,16 +1207,16 @@ class AnalysisGraph {
    *
    * @param source Source concept name
    * @param target Target concept name
-   * @param scaled_weight A value in the range [-1, 1]. Sign of the value
-   *               indicate the polarity. Delphi edge weights are angles
-   *               in the range [0, π]. Values in the range ]0, π/2[ represent
-   *               positive polarities and values in the range ]π/2, π[
-   *               represent negative polarities.
+   * @param scaled_weight A value in the range [0, 1]. Delphi edge weights are
+   *               angles in the range [0, π]. Values in the range ]0, π/2[
+   *               represents positive polarities and values in the range
+   *               ]π/2, π[ represents negative polarities.
+   * @param polarity Polarity of the edge. Should be either 1 or -1.
    * @return true if freezing the edge is successful
    *         false otherwise
    */
   bool freeze_edge_weight(std::string source, std::string target,
-                          double scaled_weight);
+                          double scaled_weight, int polarity);
 
   /*
    ============================================================================

--- a/lib/DelphiPython.cpp
+++ b/lib/DelphiPython.cpp
@@ -223,6 +223,8 @@ PYBIND11_MODULE(DelphiPython, m) {
       .def("prediction_to_array",
            &AnalysisGraph::prediction_to_array,
            "indicator"_a)
+      .def("freeze_edge_weight", &AnalysisGraph::freeze_edge_weight,
+           "source_name", "target_name", "scaled_weight", "polarity")
       .def("set_derivative", &AnalysisGraph::set_derivative)
       .def("set_default_initial_state",
            &AnalysisGraph::set_default_initial_state)

--- a/lib/causemos_integration.cpp
+++ b/lib/causemos_integration.cpp
@@ -955,3 +955,47 @@ AnalysisGraph::run_causemos_projection_experiment_from_json_file(
         return FormattedProjectionResult();
     }
 }
+
+
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                  edit-weights
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+/**
+   *
+   * @param source Source concept name
+   * @param target Target concept name
+   * @param scaled_weight A value in the range [-1, 1]. Sign of the value
+   *               indicate the polarity. Delphi edge weights are angles
+   *               in the range [0, π]. Values in the range ]0, π/2[ represent
+   *               positive polarities and values in the range ]π/2, π[
+   *               represent negative polarities.
+   * @return true if freezing the edge is successful
+   *         false otherwise
+ */
+bool AnalysisGraph::freeze_edge_weight(std::string source_name,
+                                       std::string target_name,
+                                       double scaled_weight) {
+    if (scaled_weight < -1 || scaled_weight > 1) {
+        return false;
+    }
+
+    int source_id = this->add_node(source_name);
+    int target_id = this->add_node(target_name);
+
+    pair<EdgeDescriptor, bool> edg = boost::edge(source_id, target_id,
+                                                         this->graph);
+
+    if (!edg.second) {
+        // There is no edge from source concept to target concept
+        return false;
+    }
+
+    double theta = scaled_weight * M_PI_2;
+    theta = scaled_weight >= 0 ? theta : M_PI + theta;
+
+    this->graph[edg.first].set_theta(theta);
+    this->graph[edg.first].freeze();
+
+    return true;
+}

--- a/lib/causemos_integration.cpp
+++ b/lib/causemos_integration.cpp
@@ -965,18 +965,19 @@ AnalysisGraph::run_causemos_projection_experiment_from_json_file(
    *
    * @param source Source concept name
    * @param target Target concept name
-   * @param scaled_weight A value in the range [-1, 1]. Sign of the value
-   *               indicate the polarity. Delphi edge weights are angles
-   *               in the range [0, π]. Values in the range ]0, π/2[ represent
-   *               positive polarities and values in the range ]π/2, π[
-   *               represent negative polarities.
+   * @param scaled_weight A value in the range [0, 1]. Delphi edge weights are
+   *               angles in the range [0, π]. Values in the range ]0, π/2[
+   *               represents positive polarities and values in the range
+   *               ]π/2, π[ represents negative polarities.
+   * @param polarity Polarity of the edge. Should be either 1 or -1.
    * @return true if freezing the edge is successful
    *         false otherwise
  */
 bool AnalysisGraph::freeze_edge_weight(std::string source_name,
                                        std::string target_name,
-                                       double scaled_weight) {
-    if (scaled_weight < -1 || scaled_weight > 1) {
+                                       double scaled_weight,
+                                       int polarity) {
+    if (scaled_weight < 0 || scaled_weight > 1) {
         return false;
     }
 
@@ -992,7 +993,9 @@ bool AnalysisGraph::freeze_edge_weight(std::string source_name,
     }
 
     double theta = scaled_weight * M_PI_2;
-    theta = scaled_weight >= 0 ? theta : M_PI + theta;
+    if (polarity < 0) {
+        theta = M_PI - theta;
+    }
 
     this->graph[edg.first].set_theta(theta);
     this->graph[edg.first].freeze();

--- a/lib/causemos_integration.cpp
+++ b/lib/causemos_integration.cpp
@@ -973,23 +973,37 @@ AnalysisGraph::run_causemos_projection_experiment_from_json_file(
    * @return true if freezing the edge is successful
    *         false otherwise
  */
-bool AnalysisGraph::freeze_edge_weight(std::string source_name,
+unsigned short AnalysisGraph::freeze_edge_weight(std::string source_name,
                                        std::string target_name,
                                        double scaled_weight,
                                        int polarity) {
     if (scaled_weight < 0 || scaled_weight > 1) {
-        return false;
+        return 1;
     }
 
-    int source_id = this->add_node(source_name);
-    int target_id = this->add_node(target_name);
+    int source_id = -1;
+    int target_id = -1;
+
+    try {
+        source_id = this->name_to_vertex.at(source_name);
+    } catch(const out_of_range &e) {
+        // Source concept does not exist
+        return 2;
+    }
+
+    try {
+        target_id = this->name_to_vertex.at(target_name);
+    } catch(const out_of_range &e) {
+        // Target concept does not exist
+        return 4;
+    }
 
     pair<EdgeDescriptor, bool> edg = boost::edge(source_id, target_id,
                                                          this->graph);
 
     if (!edg.second) {
         // There is no edge from source concept to target concept
-        return false;
+        return 8;
     }
 
     double theta = scaled_weight * M_PI_2;
@@ -1000,5 +1014,5 @@ bool AnalysisGraph::freeze_edge_weight(std::string source_name,
     this->graph[edg.first].set_theta(theta);
     this->graph[edg.first].freeze();
 
-    return true;
+    return 0;
 }

--- a/lib/causemos_integration.cpp
+++ b/lib/causemos_integration.cpp
@@ -970,8 +970,11 @@ AnalysisGraph::run_causemos_projection_experiment_from_json_file(
    *               represents positive polarities and values in the range
    *               ]π/2, π[ represents negative polarities.
    * @param polarity Polarity of the edge. Should be either 1 or -1.
-   * @return true if freezing the edge is successful
-   *         false otherwise
+   * @return 0 freezing the edge is successful
+   *         1 scaled_weight outside accepted range
+   *         2 Source concept does not exist
+   *         4 Target concept does not exist
+   *         8 Edge does not exist
  */
 unsigned short AnalysisGraph::freeze_edge_weight(std::string source_name,
                                        std::string target_name,

--- a/lib/to_json.cpp
+++ b/lib/to_json.cpp
@@ -149,8 +149,8 @@ string AnalysisGraph::serialize_to_json_string(bool verbose, bool compact) {
                               {obj.adjective, obj.polarity, obj.concept_name}};
         }
         if (verbose) {
-            j["edges"].push_back({{"source",name_to_vertex.at(source.name)},
-                                {"target", name_to_vertex.at(target.name)},
+            j["edges"].push_back({{"source", source.name},
+                                {"target", target.name},
                                 {"kernels", compact ? vector<double>()
                                                     : this->edge(e).kde.dataset},
                                 {"evidence", evidence},
@@ -158,7 +158,9 @@ string AnalysisGraph::serialize_to_json_string(bool verbose, bool compact) {
                                 {"log_prior_hist",
                                    compact ? vector<double>()
                                            : this->edge(e).kde.log_prior_hist},
-                                {"n_bins", this->edge(e).kde.n_bins}});
+                                {"n_bins", this->edge(e).kde.n_bins},
+                                {"theta", this->edge(e).get_theta()},
+                                {"is_frozen", this->edge(e).is_frozen()}});
         }
         else {
             // This is a more compressed version of edges. We do not utilize space
@@ -172,7 +174,9 @@ string AnalysisGraph::serialize_to_json_string(bool verbose, bool compact) {
                                                 : this->edge(e).kde.dataset,
                                             compact ? vector<double>()
                                                 : this->edge(e).kde.log_prior_hist,
-                                            this->edge(e).kde.n_bins));
+                                            this->edge(e).kde.n_bins,
+                                            this->edge(e).get_theta(),
+                                            this->edge(e).is_frozen()));
         }
     }
 


### PR DESCRIPTION
Completed the backend CauseMos integration implementation for edit edges by plumbing in the edge freeze feature I implemented a while ago into a method in the causemos_integration.cpp (unsigned short AnalysisGraph::freeze_edge_weight()

Fixed some bugs in AnalysisGraph::from_delphi_json_dict() caused when deserializing a verbose model dump.