### PR TITLE
0 delphi return average of the edge distribution to cause mos

### DIFF
--- a/lib/AnalysisGraph.hpp
+++ b/lib/AnalysisGraph.hpp
@@ -1208,9 +1208,9 @@ class AnalysisGraph {
    * @param source Source concept name
    * @param target Target concept name
    * @param scaled_weight A value in the range [0, 1]. Delphi edge weights are
-   *               angles in the range [0, π]. Values in the range ]0, π/2[
+   *               angles in the range [-π/2, π/2]. Values in the range ]0, π/2[
    *               represents positive polarities and values in the range
-   *               ]π/2, π[ represents negative polarities.
+   *               ]-π/2, 0[ represents negative polarities.
    * @param polarity Polarity of the edge. Should be either 1 or -1.
    * @return 0 freezing the edge is successful
    *         1 scaled_weight outside accepted range

--- a/lib/Edge.hpp
+++ b/lib/Edge.hpp
@@ -87,13 +87,13 @@ class Edge {
 
   void set_theta(double theta) {
       if (!this->frozen) {
-          if (0 <= theta && theta <= M_PI) {
+          if (-M_PI_2 < theta && theta < M_PI_2) {
               this->theta = theta;
           }
-          else if (-M_PI <= theta && theta < 0) {
-              this->theta = M_PI + theta;
+          else if (-3 * M_PI_2 < theta && theta < -M_PI_2) {
+              this->theta = theta + M_PI;
           }
-          else if (M_PI < theta && theta <= 2 * M_PI) {
+          else if (M_PI_2 < theta && theta < 3 * M_PI_2) {
               this->theta = theta - M_PI;
           }
           else {

--- a/lib/KDE.cpp
+++ b/lib/KDE.cpp
@@ -47,7 +47,7 @@ KDE::KDE(vector<double> thetas, int n_bins)  : n_bins(n_bins) {
 //  int bin_hi = 0;
 
   for (double theta : thetas) {
-    theta = theta < 0 ? M_PI + theta : theta;
+//    theta = theta < 0 ? M_PI + theta : theta;
 
     int bin = this->theta_to_bin(theta);
 //    bin_lo = bin < bin_lo ? bin : bin_lo;
@@ -79,7 +79,7 @@ void KDE::set_num_bins(int n_bins) {
 }
 
 int KDE::theta_to_bin(double theta) {
-    return floor(theta / this->delta_theta);
+    return floor(theta + M_PI_2 / this->delta_theta);
 }
 
 

--- a/lib/causemos_integration.cpp
+++ b/lib/causemos_integration.cpp
@@ -967,9 +967,9 @@ AnalysisGraph::run_causemos_projection_experiment_from_json_file(
    * @param source Source concept name
    * @param target Target concept name
    * @param scaled_weight A value in the range [0, 1]. Delphi edge weights are
-   *               angles in the range [0, π]. Values in the range ]0, π/2[
+   *               angles in the range [-π/2, π/2]. Values in the range ]0, π/2[
    *               represents positive polarities and values in the range
-   *               ]π/2, π[ represents negative polarities.
+   *               ]-π/2, 0[ represents negative polarities.
    * @param polarity Polarity of the edge. Should be either 1 or -1.
    * @return 0 freezing the edge is successful
    *         1 scaled_weight outside accepted range

--- a/lib/causemos_integration.cpp
+++ b/lib/causemos_integration.cpp
@@ -874,8 +874,9 @@ string AnalysisGraph::generate_create_model_response() {
         json edge_json = {{"source", this->source(e).name},
                           {"target", this->target(e).name},
                           {"weights", this->trained
-                                          ? this->graph[e].sampled_thetas
-                                          : vector<double>{0.5}}};
+                             ? vector<double>{(mean(this->graph[e].sampled_thetas)
+                                                            + M_PI_2) * M_2_PI - 1}
+                             : vector<double>{0.5}}};
 
         j["relations"].push_back(edge_json);
     }
@@ -1009,10 +1010,7 @@ unsigned short AnalysisGraph::freeze_edge_weight(std::string source_name,
         return 8;
     }
 
-    double theta = scaled_weight * M_PI_2;
-    if (polarity < 0) {
-        theta = M_PI - theta;
-    }
+    double theta = polarity / abs(polarity) * scaled_weight * M_PI_2;
 
     this->graph[edg.first].set_theta(theta);
     this->graph[edg.first].freeze();

--- a/lib/parameter_initialization.cpp
+++ b/lib/parameter_initialization.cpp
@@ -452,7 +452,7 @@ void AnalysisGraph::construct_theta_pdfs() {
           get(adjective_response_map, obj_adjective, marginalized_responses));
 
       for (auto [x, y] : ranges::views::cartesian_product(subj_responses, obj_responses)) {
-        all_thetas.push_back(atan2(sigma_Y * y, sigma_X * x));
+          all_thetas.push_back(atan((sigma_Y * y) / (sigma_X * x)));
       }
     }
 


### PR DESCRIPTION
Implemented reporting learned edge weights to CauseMos as a scaled number in the range [-1, 1]
    
    Changed the theta range used as edge weights to ]-π/2, π/2[ to make the
    range continuous. Earlier it was [0, π] and then the range becomes
    discontinuous at π/2 since tan(π/2) is infinity.