### PR TITLE
Fixed a bug related to freezing edges.

### DIFF
--- a/apps/create_model.cpp
+++ b/apps/create_model.cpp
@@ -478,26 +478,36 @@ int main(int argc, char* argv[]) {
   AnalysisGraph G = AnalysisGraph::from_causemos_json_file(
     "../tests/data/delphi/create_model_rain--temperature--yield.json", 0);
 
-  unsigned short status = G.freeze_edge_weight(
+  G.set_n_kde_kernels(100);
+  G.run_train_model(10, 10);
+  string initial_model = G.serialize_to_json_string(false);
+
+  AnalysisGraph G2 = AnalysisGraph::deserialize_from_json_string(initial_model, false);
+  unsigned short status = G2.freeze_edge_weight(
                             "wm/concept/environment/meteorology/precipitation",
                             "wm/concept/agriculture/crop_produce",
-                            0.5, 1);
+                            0.25, 1);  // 0.392699 radians
   if (status == 0) {
-        G.print_edges();
+        G2.print_edges();
   }
   else {
       cout << "Error: " << status << endl;
   }
 
-  FormattedProjectionResult proj;
-  string frozen = G.serialize_to_json_string(false);
-  AnalysisGraph G2 = AnalysisGraph::deserialize_from_json_string(frozen, false);
-  G2.print_edges();
-
   G2.set_n_kde_kernels(100);
   G2.run_train_model(10, 10);
   cout << nlohmann::json::parse(G2.generate_create_model_response()).dump(2);
-  proj = G2.run_causemos_projection_experiment_from_json_file(
+
+  FormattedProjectionResult proj;
+  string frozen = G2.serialize_to_json_string(false);
+
+  AnalysisGraph G3 = AnalysisGraph::deserialize_from_json_string(frozen, false);
+  G3.print_edges();
+  G3.set_n_kde_kernels(100);
+  G3.run_train_model(10, 10);
+  cout << nlohmann::json::parse(G2.generate_create_model_response()).dump(2);
+
+  proj = G3.run_causemos_projection_experiment_from_json_file(
       "../tests/data/delphi/experiments_rain--temperature--yield.json");
   return(0);
 

--- a/apps/delphi_rest_api.cpp
+++ b/apps/delphi_rest_api.cpp
@@ -211,7 +211,7 @@ class Model {
     Adarsh
     */
     static int get_sampling_resolution() {
-        return 100; 
+        return 100;
     }
 
     static int get_burn() {
@@ -233,7 +233,7 @@ class Model {
 
     // freeze the edge and return a status string (Empty means OK)
     static string freeze_edge(
-        AnalysisGraph G,
+        AnalysisGraph& G,
         string source_name,
         string target_name,
         double scaled_weight,

--- a/lib/train_model.cpp
+++ b/lib/train_model.cpp
@@ -172,6 +172,7 @@ void AnalysisGraph::run_train_model(int res,
 
     this->edge_sample_pool.clear();
     for (EdgeDescriptor ed : this->edges()) {
+        this->graph[ed].sampled_thetas.clear();
         if (!this->graph[ed].is_frozen()) {
             this->edge_sample_pool.push_back(ed);
         }
@@ -285,7 +286,7 @@ void AnalysisGraph::run_train_model(int res,
       */
     }
 
-    if (this->MAP_sample_number < int(this->res) - 1) {
+    if (this->MAP_sample_number < int(this->res)) {
       this->sample_from_posterior();
       this->transition_matrix_collection[this->res - 1] = this->A_original;
       this->initial_latent_state_collection[this->res - 1] = this->s0;


### PR DESCRIPTION
1. When we
create a model
train it
serialize it
deserialize it
freeze an edge
check model status,
the frozen edge did not gave the value set for it. The sampled thetas
for a edge was not cleared when we train a model for again and again and
hence the values sampled before freezing too were included when
calculating the average edge weight.

2. Even after fixing the first bug, frozen edge were giving different
weights each time the model was trained. When checked, the REST API did
not properly froze the edge. In the REST API the deserialized
AnalysisGraph object was passed by value to another function that called
the freeze_edge_weight() method on it. Since it was called on a copy,
the changes were not applied to the object that got trained and written
to the db.