### PR TITLE
Freezing and unfreezing edges

### DIFF
--- a/lib/causemos_integration.cpp
+++ b/lib/causemos_integration.cpp
@@ -1085,10 +1085,6 @@ unsigned short AnalysisGraph::freeze_edge_weight(std::string source_name,
                                        std::string target_name,
                                        double scaled_weight,
                                        int polarity) {
-    if (scaled_weight < 0 || scaled_weight > 1) {
-        return 1;
-    }
-
     int source_id = -1;
     int target_id = -1;
 
@@ -1114,8 +1110,21 @@ unsigned short AnalysisGraph::freeze_edge_weight(std::string source_name,
         return 8;
     }
 
+    if (polarity == 0) {
+        this->graph[edg.first].unfreeze();
+        // Prevent initializing the model parameters to the MAP estimate of the
+        // previous training run to give a warm start to training
+        this->MAP_sample_number = -1;
+        return 0;
+    }
+
+    if (scaled_weight < 0 || scaled_weight >= 1) {
+        return 1;
+    }
+
     double theta = polarity / abs(polarity) * scaled_weight * M_PI_2;
 
+    this->graph[edg.first].unfreeze();
     this->graph[edg.first].set_theta(theta);
     this->graph[edg.first].freeze();
 


### PR DESCRIPTION
1. Allowed re-freezing an already frozen edge to a new value. Since we
are warm starting training, the newly sampled edge weights for
non-frozen edges could end up being close to the previously trained
model.

2. Overloaded the AnalysisGraph::freeze_edge_weight() method to unfreeze
an edge by providing a polarity of 0. In this case warm starting the
training based on the MAP estimate of the previous training run is
disabled to enable fresh training.